### PR TITLE
Ensure updates atomic and add merge operator

### DIFF
--- a/src/main/java/mb/rxui/property/EventSequenceGenerator.java
+++ b/src/main/java/mb/rxui/property/EventSequenceGenerator.java
@@ -39,10 +39,19 @@ class EventSequenceGenerator {
      * 
      * @return a sequence number that is guaranteed not to be unique.
      */
-    long next() {
+    long nextSequenceNumber() {
         long nextSequence = lastSequenceNumber++;
         sequenceMap.put(nextSequence, System.currentTimeMillis());
         return nextSequence;
+    }
+    
+    /**
+     * @deprecated this will be removed once an interface for Event Sequencer is
+     *             created. Should only be used by tests
+     */
+    void reset() {
+        lastSequenceNumber = 0;
+        sequenceMap.clear();
     }
     
     /**

--- a/src/main/java/mb/rxui/property/Property.java
+++ b/src/main/java/mb/rxui/property/Property.java
@@ -23,6 +23,8 @@ import javax.security.auth.Subject;
 import mb.rxui.ThreadChecker;
 import mb.rxui.disposables.Disposable;
 import mb.rxui.property.dispatcher.Dispatcher;
+import mb.rxui.property.publisher.PropertyPublisher;
+import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
 /**
@@ -69,7 +71,7 @@ public class Property<M> extends PropertyObservable<M> implements PropertySource
     private final ThreadChecker threadChecker;
 
     private Property(PropertySource<M> propertySource, Dispatcher<M> dispatcher) {
-        super(new PropertyPublisherImpl<>(propertySource, dispatcher));
+        super(PropertyPublisher.create(propertySource, dispatcher));
         this.propertySource = requireNonNull(propertySource);
         this.dispatcher = requireNonNull(dispatcher);
         this.initialValue = requireNonNull(get(), "A Property must be initialized with a value");
@@ -173,7 +175,7 @@ public class Property<M> extends PropertyObservable<M> implements PropertySource
 
     public final boolean hasObservers() {
         threadChecker.checkThread();
-        return dispatcher.hasSubscribers();
+        return dispatcher.getSubscriberCount() > 0;
     }
     
     // Factory methods

--- a/src/main/java/mb/rxui/property/Property.java
+++ b/src/main/java/mb/rxui/property/Property.java
@@ -133,7 +133,7 @@ public class Property<M> extends PropertyObservable<M> implements PropertySource
      *             allow it since it will not cause any harm (I think).
      */
     public final Subscription bind(PropertyObservable<M> propertyToBindTo) {
-        return propertyToBindTo.onChanged(this);
+        return propertyToBindTo.observe(new Binding<>(this));
     }
     
     /**
@@ -176,6 +176,17 @@ public class Property<M> extends PropertyObservable<M> implements PropertySource
     public final boolean hasObservers() {
         threadChecker.checkThread();
         return dispatcher.getSubscriberCount() > 0;
+    }
+    
+    /**
+     * @return an {@link Observable} stream of property change events for this property.
+     */
+    public final Observable<PropertyChangeEvent<M>> changeEvents() {
+        return asObservable().scan(Optional.<PropertyChangeEvent<M>>empty(),
+                                   (lastEvent, newValue)  -> PropertyChangeEvent.next(lastEvent, newValue))
+                             .filter(Optional::isPresent)
+                             .filter(optional -> optional.get().getOldValue() != null)
+                             .map(Optional::get);
     }
     
     // Factory methods

--- a/src/main/java/mb/rxui/property/PropertyChangeEvent.java
+++ b/src/main/java/mb/rxui/property/PropertyChangeEvent.java
@@ -36,7 +36,7 @@ public class PropertyChangeEvent<M> {
     }
     
     public PropertyChangeEvent(M oldValue, M newValue) {
-        this(oldValue, newValue, EventSequenceGenerator.getInstance().next());
+        this(oldValue, newValue, EventSequenceGenerator.getInstance().nextSequenceNumber());
     }
     
     /**

--- a/src/main/java/mb/rxui/property/PropertyObservable.java
+++ b/src/main/java/mb/rxui/property/PropertyObservable.java
@@ -34,6 +34,9 @@ import mb.rxui.property.operator.OperatorMap;
 import mb.rxui.property.operator.OperatorTake;
 import mb.rxui.property.operator.PropertyConditionBuilder;
 import mb.rxui.property.operator.PropertyOperator;
+import mb.rxui.property.publisher.CombinePropertyPublisher;
+import mb.rxui.property.publisher.MergePropertyPublisher;
+import mb.rxui.property.publisher.PropertyPublisher;
 import rx.Observable;
 import rx.subscriptions.Subscriptions;
 
@@ -242,6 +245,10 @@ public class PropertyObservable<M> implements Supplier<M> {
         return lift(new OperatorTake<>(amount));
     }
     
+    public final PropertyObservable<M> mergeWith(PropertyObservable<M> observableToMergeWith) {
+        return PropertyObservable.merge(this, observableToMergeWith);
+    }
+    
     /**
      * Using the provided operator creates a new, converted property observable.
      * 
@@ -276,6 +283,7 @@ public class PropertyObservable<M> implements Supplier<M> {
         return asObservable().scan(Optional.<PropertyChangeEvent<M>>empty(),
                                    (lastEvent, newValue)  -> PropertyChangeEvent.next(lastEvent, newValue))
                              .filter(Optional::isPresent)
+                             .filter(optional -> optional.get().getOldValue() != null)
                              .map(Optional::get);
     }
     
@@ -324,10 +332,30 @@ public class PropertyObservable<M> implements Supplier<M> {
      *         the values of the provided observables using the provided
      *         function any time either observables' value changes.
      */
-    public static <T1, T2, R> PropertyObservable<R> combine(PropertyObservable<T1> observable1, PropertyObservable<T2> observable2, BiFunction<T1, T2, R> combiner) {
+    public static <T1, T2, R> PropertyObservable<R> combine(PropertyObservable<T1> observable1, 
+                                                            PropertyObservable<T2> observable2, 
+                                                            BiFunction<T1, T2, R> combiner) {
         List<PropertyObservable<?>> observables = Arrays.asList(observable1, observable2);
         Supplier<R> combineSupplier = () -> combiner.apply(observable1.get(), observable2.get());
         
         return new PropertyObservable<R>(new CombinePropertyPublisher<R>(combineSupplier, observables));
+    }
+    
+    /**
+     * Merges the provided property observables into one property observable.
+     * When initializing the subscriber will be called back with the current
+     * value of each stream in the order the observables where provided. After
+     * which, any time any of the provided property observables values change
+     * the subscriber will be called back with that value.
+     * 
+     * @param observables
+     *            the observables to be merged
+     * @return a new {@link PropertyObservable} that will fire onChanged any
+     *         time one of the provided property observables values change.
+     */
+    @SafeVarargs
+    public static <R> PropertyObservable<R> merge(PropertyObservable<R>... observables) {
+        List<PropertyObservable<R>> observableList = Arrays.asList(observables);
+        return new PropertyObservable<>(new MergePropertyPublisher<>(observableList));
     }
 }

--- a/src/main/java/mb/rxui/property/PropertyObservable.java
+++ b/src/main/java/mb/rxui/property/PropertyObservable.java
@@ -279,14 +279,6 @@ public class PropertyObservable<M> implements Supplier<M> {
         });
     }
     
-    public final Observable<PropertyChangeEvent<M>> getChangeEvents() {
-        return asObservable().scan(Optional.<PropertyChangeEvent<M>>empty(),
-                                   (lastEvent, newValue)  -> PropertyChangeEvent.next(lastEvent, newValue))
-                             .filter(Optional::isPresent)
-                             .filter(optional -> optional.get().getOldValue() != null)
-                             .map(Optional::get);
-    }
-    
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/src/main/java/mb/rxui/property/PropertyObserver.java
+++ b/src/main/java/mb/rxui/property/PropertyObserver.java
@@ -40,6 +40,11 @@ public interface PropertyObserver<M> {
      */
     void onDisposed();
     
+    /**
+     * @return true if this observer is represents a binding, false otherwise.
+     */
+    boolean isBinding();
+    
     // Factory methods
 
     /**
@@ -86,6 +91,11 @@ public interface PropertyObserver<M> {
             @Override
             public void onDisposed() {
                 onDisposed.run();
+            }
+            
+            @Override
+            public boolean isBinding() {
+                return false;
             }
         };
     }

--- a/src/main/java/mb/rxui/property/PropertySubscriber.java
+++ b/src/main/java/mb/rxui/property/PropertySubscriber.java
@@ -97,4 +97,9 @@ public class PropertySubscriber<M> implements PropertyObserver<M>, Subscription 
             }
         };
     }
+
+    @Override
+    public boolean isBinding() {
+        return observer.isBinding();
+    }
 }

--- a/src/main/java/mb/rxui/property/dispatcher/Dispatcher.java
+++ b/src/main/java/mb/rxui/property/dispatcher/Dispatcher.java
@@ -57,9 +57,9 @@ public interface Dispatcher<V> extends Disposable {
     boolean isDisposed();
 
     /**
-     * @return true if this dispatcher currently has any subscribers
+     * @return the number of subscribers to this dispatcher.
      */
-    boolean hasSubscribers();
+    int getSubscriberCount();
 
     /**
      * Adds an observer to this dispatcher.

--- a/src/main/java/mb/rxui/property/dispatcher/PropertyDispatcher.java
+++ b/src/main/java/mb/rxui/property/dispatcher/PropertyDispatcher.java
@@ -74,8 +74,8 @@ public final class PropertyDispatcher<M> implements Dispatcher<M> {
     }
     
     @Override
-    public boolean hasSubscribers() {
-        return ! subscribers.isEmpty();
+    public int getSubscriberCount() {
+        return subscribers.size();
     }
     
     @Override

--- a/src/main/java/mb/rxui/property/javafx/ObservableValuePropertyPublisher.java
+++ b/src/main/java/mb/rxui/property/javafx/ObservableValuePropertyPublisher.java
@@ -18,8 +18,8 @@ import static java.util.Objects.requireNonNull;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import mb.rxui.property.PropertyObserver;
-import mb.rxui.property.PropertyPublisher;
 import mb.rxui.property.PropertySubscriber;
+import mb.rxui.property.publisher.PropertyPublisher;
 
 public class ObservableValuePropertyPublisher<T> implements PropertyPublisher<T> {
 

--- a/src/main/java/mb/rxui/property/operator/OperatorFilter.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorFilter.java
@@ -16,8 +16,8 @@ package mb.rxui.property.operator;
 import java.util.function.Predicate;
 
 import mb.rxui.property.PropertyObserver;
-import mb.rxui.property.PropertyPublisher;
 import mb.rxui.property.PropertySubscriber;
+import mb.rxui.property.publisher.PropertyPublisher;
 
 /**
  * Operator that filters the values emitted by the source property observable

--- a/src/main/java/mb/rxui/property/operator/OperatorFilter.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorFilter.java
@@ -54,8 +54,8 @@ public class OperatorFilter<M> implements PropertyOperator<M, M> {
                 
                 PropertySubscriber<M> sourceSubscriber = 
                         source.subscribe(PropertyObserver.<M>create(value -> { 
-                            if (predicate.test(value))
-                                subscriber.onChanged(value); 
+                            if (predicate.test(get()))
+                                subscriber.onChanged(get()); 
                             },
                             subscriber::onDisposed));
                 

--- a/src/main/java/mb/rxui/property/operator/OperatorFilterToOptional.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorFilterToOptional.java
@@ -60,7 +60,7 @@ public class OperatorFilterToOptional<M> implements PropertyOperator<M, Optional
                 PropertySubscriber<Optional<M>> subscriber = new PropertySubscriber<>(observer);
                 
                 PropertySubscriber<M> sourceSubscriber = 
-                        source.subscribe(PropertyObserver.<M>create(value -> subscriber.onChanged(filteredValue(value)),
+                        source.subscribe(PropertyObserver.<M>create(value -> subscriber.onChanged(get()),
                                                                     subscriber::onDisposed));
                 
                 subscriber.doOnUnsubscribe(sourceSubscriber::dispose);

--- a/src/main/java/mb/rxui/property/operator/OperatorFilterToOptional.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorFilterToOptional.java
@@ -17,8 +17,8 @@ import java.util.Optional;
 import java.util.function.Predicate;
 
 import mb.rxui.property.PropertyObserver;
-import mb.rxui.property.PropertyPublisher;
 import mb.rxui.property.PropertySubscriber;
+import mb.rxui.property.publisher.PropertyPublisher;
 
 /**
  * Filters values based on some predicate. Emits an Optional empty if the
@@ -38,8 +38,8 @@ public class OperatorFilterToOptional<M> implements PropertyOperator<M, Optional
      */
     public OperatorFilterToOptional(Predicate<M> predicate) {
         this.predicate = predicate;
-        
     }
+    
     @Override
     public PropertyPublisher<Optional<M>> apply(PropertyPublisher<M> source) {
         

--- a/src/main/java/mb/rxui/property/operator/OperatorIs.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorIs.java
@@ -20,8 +20,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import mb.rxui.property.PropertyObserver;
-import mb.rxui.property.PropertyPublisher;
 import mb.rxui.property.PropertySubscriber;
+import mb.rxui.property.publisher.PropertyPublisher;
 
 /**
  * A {@link PropertyOperator} that transforms the property observable into a

--- a/src/main/java/mb/rxui/property/operator/OperatorIs.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorIs.java
@@ -62,7 +62,7 @@ public class OperatorIs<M> implements PropertyOperator<M, Boolean> {
                 PropertySubscriber<Boolean> isSubscriber = new PropertySubscriber<>(observer);
                 
                 PropertySubscriber<M> sourceSubscriber = 
-                        source.subscribe(PropertyObserver.<M>create(value -> isSubscriber.onChanged(is(value)),
+                        source.subscribe(PropertyObserver.<M>create(value -> isSubscriber.onChanged(get()),
                                                                     isSubscriber::onDisposed));
                 
                 isSubscriber.doOnUnsubscribe(sourceSubscriber::dispose);

--- a/src/main/java/mb/rxui/property/operator/OperatorIsDirty.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorIsDirty.java
@@ -43,7 +43,7 @@ public class OperatorIsDirty<M> implements PropertyOperator<M, Boolean> {
                 PropertySubscriber<Boolean> isDirtySubscriber = new PropertySubscriber<>(observer);
                 
                 PropertySubscriber<M> sourceSubscriber = 
-                        sourcePublisher.subscribe(PropertyObserver.<M>create(value -> isDirtySubscriber.onChanged(isDirty(value)),
+                        sourcePublisher.subscribe(PropertyObserver.<M>create(value -> isDirtySubscriber.onChanged(get()),
                                                   isDirtySubscriber::onDisposed));
                 
                 isDirtySubscriber.doOnUnsubscribe(sourceSubscriber::dispose);

--- a/src/main/java/mb/rxui/property/operator/OperatorIsDirty.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorIsDirty.java
@@ -14,8 +14,8 @@
 package mb.rxui.property.operator;
 
 import mb.rxui.property.PropertyObserver;
-import mb.rxui.property.PropertyPublisher;
 import mb.rxui.property.PropertySubscriber;
+import mb.rxui.property.publisher.PropertyPublisher;
 
 public class OperatorIsDirty<M> implements PropertyOperator<M, Boolean> {
 

--- a/src/main/java/mb/rxui/property/operator/OperatorMap.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorMap.java
@@ -16,8 +16,8 @@ package mb.rxui.property.operator;
 import java.util.function.Function;
 
 import mb.rxui.property.PropertyObserver;
-import mb.rxui.property.PropertyPublisher;
 import mb.rxui.property.PropertySubscriber;
+import mb.rxui.property.publisher.PropertyPublisher;
 
 public class OperatorMap<Downstream, Upstream> implements PropertyOperator<Downstream, Upstream>{
 

--- a/src/main/java/mb/rxui/property/operator/OperatorTake.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorTake.java
@@ -15,8 +15,8 @@ package mb.rxui.property.operator;
 
 import mb.rxui.property.PropertyObservable;
 import mb.rxui.property.PropertyObserver;
-import mb.rxui.property.PropertyPublisher;
 import mb.rxui.property.PropertySubscriber;
+import mb.rxui.property.publisher.PropertyPublisher;
 
 /**
  * An operator that limits the number of values dispatched to subscribers.<br>

--- a/src/main/java/mb/rxui/property/operator/PropertyOperator.java
+++ b/src/main/java/mb/rxui/property/operator/PropertyOperator.java
@@ -15,7 +15,7 @@ package mb.rxui.property.operator;
 
 import java.util.function.Function;
 
-import mb.rxui.property.PropertyPublisher;
+import mb.rxui.property.publisher.PropertyPublisher;
 
 /**
  * A {@link PropertyOperator} is some function that can convert a property

--- a/src/main/java/mb/rxui/property/publisher/CombinePropertyPublisher.java
+++ b/src/main/java/mb/rxui/property/publisher/CombinePropertyPublisher.java
@@ -11,13 +11,19 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package mb.rxui.property;
+package mb.rxui.property.publisher;
 
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import mb.rxui.property.CompositeSubscription;
+import mb.rxui.property.PropertyObservable;
+import mb.rxui.property.PropertyObserver;
+import mb.rxui.property.PropertySubscriber;
+import mb.rxui.property.Subscription;
 
 /**
  * A {@link PropertyPublisher} that will combine the values of the provided
@@ -62,7 +68,7 @@ public class CombinePropertyPublisher<R> implements PropertyPublisher<R> {
                                                                  if (incrementDisposeCount())
                                                                      combineSubscriber.onDisposed();
                                                              }))
-                  .collect(Collectors.toList());
+                       .collect(Collectors.toList());
         
         CompositeSubscription subscription = new CompositeSubscription(subscriptions);
         

--- a/src/main/java/mb/rxui/property/publisher/MergePropertyPublisher.java
+++ b/src/main/java/mb/rxui/property/publisher/MergePropertyPublisher.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2015 Mike Baum
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package mb.rxui.property.publisher;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import mb.rxui.property.CompositeSubscription;
+import mb.rxui.property.PropertyObservable;
+import mb.rxui.property.PropertyObserver;
+import mb.rxui.property.PropertySubscriber;
+import mb.rxui.property.Subscription;
+
+public class MergePropertyPublisher<R> implements PropertyPublisher<R> {
+
+    private final List<PropertyObservable<R>> observables;
+    private int disposeCount = 0;
+    private R currentValue;
+    
+    public MergePropertyPublisher(List<PropertyObservable<R>> observables) {
+        this.observables = Objects.requireNonNull(observables);
+        this.currentValue = observables.get(0).get();
+    }
+    
+    /**
+     * @return true if the disposeCount equals the number of observables that have been subscribed to.
+     */
+    private boolean incrementDisposeCount() {
+        disposeCount++;
+        return disposeCount == observables.size();
+    }
+    
+    @Override
+    public R get() {
+        return currentValue;
+    }
+
+    @Override
+    public PropertySubscriber<R> subscribe(PropertyObserver<R> observer) {
+        
+        PropertySubscriber<R> mergeSubscriber = new PropertySubscriber<>(observer);
+        
+        AtomicBoolean hasEmittedFirstValue = new AtomicBoolean(false);
+        
+        List<Subscription> subscriptions = 
+            observables.stream()
+                       .map(subscribe(mergeSubscriber, hasEmittedFirstValue))
+                       .collect(Collectors.toList());
+        
+        CompositeSubscription subscription = new CompositeSubscription(subscriptions);
+        
+        mergeSubscriber.doOnUnsubscribe(subscription::dispose);
+        
+        return mergeSubscriber;
+    }
+
+    private Function<? super PropertyObservable<R>, ? extends Subscription> 
+        subscribe(PropertySubscriber<R> mergeSubscriber, AtomicBoolean hasEmittedFirstValue) {
+        
+        return observable -> observable.observe(value -> {
+            if (!value.equals(get()) || hasEmittedFirstValue.compareAndSet(false, true)) {
+                MergePropertyPublisher.this.currentValue = value;
+                mergeSubscriber.onChanged(get());
+            }
+        } , () -> {
+            if (incrementDisposeCount())
+                mergeSubscriber.onDisposed();
+        });
+    }
+}

--- a/src/main/java/mb/rxui/property/publisher/PropertyPublisher.java
+++ b/src/main/java/mb/rxui/property/publisher/PropertyPublisher.java
@@ -11,15 +11,19 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package mb.rxui.property;
+package mb.rxui.property.publisher;
 
 import java.util.function.Supplier;
+
+import mb.rxui.property.PropertyObserver;
+import mb.rxui.property.PropertySubscriber;
+import mb.rxui.property.dispatcher.Dispatcher;
 
 /**
  * A {@link PropertyPublisher} represents some source of property updates.
  * 
  * @param <T>
- *            the type of the valie this publisher provides
+ *            the type of the value this publisher provides
  */
 public interface PropertyPublisher<T> extends Supplier<T> {
     /**
@@ -31,4 +35,14 @@ public interface PropertyPublisher<T> extends Supplier<T> {
      *         subscription
      */
     PropertySubscriber<T> subscribe(PropertyObserver<T> observer);
+    
+    /**
+     * Creates a default {@link PropertyPublisher}.
+     * @param propertySupplier some supplier that provides property values.
+     * @param dispatcher some dispatcher to dispatch property events.
+     * @return a new {@link PropertyPublisher}
+     */
+    static <T> PropertyPublisher<T> create(Supplier<T> propertySupplier, Dispatcher<T> dispatcher) {
+        return new PropertyPublisherImpl<>(propertySupplier, dispatcher);
+    }
 }

--- a/src/main/java/mb/rxui/property/publisher/PropertyPublisherImpl.java
+++ b/src/main/java/mb/rxui/property/publisher/PropertyPublisherImpl.java
@@ -57,8 +57,10 @@ final class PropertyPublisherImpl<T> implements PropertyPublisher<T> {
      * 
      * @param observer
      *            some property subscriber.
-     * @return TODO
-     * @throws IllegalStateException if called when the dispatcher has already been disposed.
+     * @return A {@link PropertySubscriber} that wraps the provided observer.
+     *         The subscriber ensures that the contract of property is upheld,
+     *         i.e. blocks reentrancy and prevents an exception from stopping
+     *         other callbacks from executing.
      */
     @Override
     public PropertySubscriber<T> subscribe(PropertyObserver<T> observer) {

--- a/src/main/java/mb/rxui/property/publisher/PropertyPublisherImpl.java
+++ b/src/main/java/mb/rxui/property/publisher/PropertyPublisherImpl.java
@@ -11,13 +11,15 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package mb.rxui.property;
+package mb.rxui.property.publisher;
 
 import static java.util.Objects.requireNonNull;
-import static mb.rxui.Preconditions.checkArgument;
 
+import java.util.Objects;
 import java.util.function.Supplier;
 
+import mb.rxui.property.PropertyObserver;
+import mb.rxui.property.PropertySubscriber;
 import mb.rxui.property.dispatcher.Dispatcher;
 
 /**
@@ -46,7 +48,7 @@ final class PropertyPublisherImpl<T> implements PropertyPublisher<T> {
     public PropertyPublisherImpl(Supplier<T> propertySupplier, Dispatcher<T> dispatcher) {
         this.propertySupplier = requireNonNull(propertySupplier);
         this.dispatcher = requireNonNull(dispatcher);
-        checkArgument(propertySupplier.get() != null, "A property publisher must be initialized with a value");
+        Objects.requireNonNull(propertySupplier.get(), "A property publisher must be initialized with a value");
     }
     
     

--- a/src/test/java/mb/rxui/property/TestCombineLatest.java
+++ b/src/test/java/mb/rxui/property/TestCombineLatest.java
@@ -37,7 +37,7 @@ public class TestCombineLatest {
         assertFalse(property2.hasObservers());
         
         Subscription subscription = observable.observe(observer);
-        verify(observer, times(2)).onChanged("I ate [15] tacos");
+        verify(observer).onChanged("I ate [15] tacos");
         verifyNoMoreInteractions(observer);
         
         assertTrue(property.hasObservers());

--- a/src/test/java/mb/rxui/property/TestJavaFxProperties.java
+++ b/src/test/java/mb/rxui/property/TestJavaFxProperties.java
@@ -16,8 +16,8 @@ package mb.rxui.property;
 import static mb.rxui.property.javafx.JavaFxProperties.fromFxProperty;
 import static mb.rxui.property.javafx.JavaFxProperties.fromObservableValue;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.After;
 import org.junit.Before;
@@ -61,12 +61,12 @@ public class TestJavaFxProperties {
             
             property.observe(observer);
             verify(observer).onChanged("tacos");
-            verifyNoMoreInteractions(observer);
+            verify(observer, never()).onDisposed();
             
             fxStringProperty.setValue("burritos");
             verify(observer).onChanged("burritos");
             assertEquals("burritos", property.get());
-            verifyNoMoreInteractions(observer);
+            verify(observer, never()).onDisposed();
         });
     }
     
@@ -77,13 +77,13 @@ public class TestJavaFxProperties {
             
             property.observe(observer);
             verify(observer).onChanged("tacos");
-            verifyNoMoreInteractions(observer);
+            verify(observer, never()).onDisposed();
             
             property.setValue("burritos");
             verify(fxStringProperty).setValue("burritos");
             assertEquals("burritos", fxStringProperty.getValue());
             verify(observer).onChanged("burritos");
-            verifyNoMoreInteractions(observer);
+            verify(observer, never()).onDisposed();
         } );
     }
     

--- a/src/test/java/mb/rxui/property/TestProperty.java
+++ b/src/test/java/mb/rxui/property/TestProperty.java
@@ -392,33 +392,51 @@ public class TestProperty {
 
         InOrder inOrder = Mockito.inOrder(consumer1, consumer2, consumer3);
 
-        Subscription consumerSubscription1 = property1.onChanged(consumer1);
-        Subscription consumerSubscription2 = property2.onChanged(consumer2);
-        Subscription consumerSubscription3 = property3.onChanged(consumer3);
+        Subscription subscription1 = property1.onChanged(consumer1);
+        property1.onChanged(System.out::println);
+        inOrder.verify(consumer1).accept("tacos");
+        
+        
+        Subscription subscription2 = property2.onChanged(consumer2);
+        inOrder.verify(consumer2).accept("burritos");
+        
+        
+        Subscription subscription3 = property3.onChanged(consumer3);
+        inOrder.verify(consumer3).accept("fajitas");
 
+        
         Subscription bindSubscription1 = property1.bind(property2);
-        Subscription bindSubscription2 = property2.bind(property3);
-        Subscription bindSubscription3 = property3.bind(property1);
-
         inOrder.verify(consumer1).accept("burritos");
-        inOrder.verify(consumer2).accept("fajitas");
+        
+        
+        Subscription bindSubscription2 = property2.bind(property3);
         inOrder.verify(consumer1).accept("fajitas");
+        inOrder.verify(consumer2).accept("fajitas");
+        
+        Subscription bindSubscription3 = property3.bind(property1);
+        
+        assertEquals("fajitas", property1.get());
+        assertEquals("fajitas", property2.get());
+        assertEquals("fajitas", property3.get());
+
         inOrder.verifyNoMoreInteractions();
 
         property2.setValue("nachos");
-        inOrder.verify(consumer1).accept("nachos"); // accept the nachos, or
-                                                    // accept death
         inOrder.verify(consumer3).accept("nachos");
+        inOrder.verify(consumer1).accept("nachos"); // accept the nachos, or accept death
+        inOrder.verify(consumer2).accept("nachos");
         inOrder.verifyNoMoreInteractions();
 
         property3.setValue("tacos");
-        inOrder.verify(consumer2).accept("tacos");
         inOrder.verify(consumer1).accept("tacos");
+        inOrder.verify(consumer2).accept("tacos");
+        inOrder.verify(consumer3).accept("tacos");
         inOrder.verifyNoMoreInteractions();
 
         property1.setValue("burritos");
-        inOrder.verify(consumer3).accept("burritos");
         inOrder.verify(consumer2).accept("burritos");
+        inOrder.verify(consumer3).accept("burritos");
+        inOrder.verify(consumer1).accept("burritos");
         inOrder.verifyNoMoreInteractions();
     }
 
@@ -443,26 +461,29 @@ public class TestProperty {
         inOrder.verifyNoMoreInteractions();
 
         Subscription synchronize2Sub = property2.synchronize(property3);
-        inOrder.verify(consumer2).accept("fajitas");
         inOrder.verify(consumer1).accept("fajitas");
+        inOrder.verify(consumer2).accept("fajitas");
         inOrder.verifyNoMoreInteractions();
 
         Subscription synchronize3Sub = property3.synchronize(property1);
         inOrder.verifyNoMoreInteractions();
 
         property2.setValue("burritos");
-        inOrder.verify(consumer1).accept("burritos");
         inOrder.verify(consumer3).accept("burritos");
+        inOrder.verify(consumer1).accept("burritos");
+        inOrder.verify(consumer2).accept("burritos");
         inOrder.verifyNoMoreInteractions();
 
         property3.setValue("tacos");
-        inOrder.verify(consumer2).accept("tacos");
         inOrder.verify(consumer1).accept("tacos");
+        inOrder.verify(consumer2).accept("tacos");
+        inOrder.verify(consumer3).accept("tacos");
         inOrder.verifyNoMoreInteractions();
 
         property1.setValue("nachos");
-        inOrder.verify(consumer2).accept("nachos");
         inOrder.verify(consumer3).accept("nachos");
+        inOrder.verify(consumer2).accept("nachos");
+        inOrder.verify(consumer1).accept("nachos");
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/mb/rxui/property/TestPropertyChangeEvents.java
+++ b/src/test/java/mb/rxui/property/TestPropertyChangeEvents.java
@@ -15,37 +15,69 @@ package mb.rxui.property;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import rx.Observer;
+import rx.Subscription;
 
 public class TestPropertyChangeEvents {
+    
+    @Before
+    public void setup() {
+        EventSequenceGenerator.getInstance().reset();
+    }
+    
     @Test
     public void testPropertyChangeEvents() throws Exception {
         Property<String> property = Property.create("tacos");
         Property<Integer> property2 = Property.create(10);
         
+        // subscribing to property change events should not emit a change event until the value changes from the initial value.
         Observer<PropertyChangeEvent<String>> changeEventsObserver = Mockito.mock(Observer.class);
         property.getChangeEvents().subscribe(changeEventsObserver);
-        verify(changeEventsObserver).onNext(new PropertyChangeEvent<>(null, "tacos", 0));
+        verifyNoMoreInteractions(changeEventsObserver);
 
+        // subscribing to property change events should not emit a change event until the value changes from the initial value.
         Observer<PropertyChangeEvent<Integer>> changeEventsObserver2 = Mockito.mock(Observer.class);
         property2.getChangeEvents().subscribe(changeEventsObserver2);
-        verify(changeEventsObserver2).onNext(new PropertyChangeEvent<>(null, 10, 1));
+        verifyNoMoreInteractions(changeEventsObserver2);
         
         property.setValue("burritos");
-        verify(changeEventsObserver).onNext(new PropertyChangeEvent<>("tacos", "burritos", 2));
-        Mockito.verifyNoMoreInteractions(changeEventsObserver);
+        verify(changeEventsObserver).onNext(new PropertyChangeEvent<>("tacos", "burritos", 4));
+        verifyNoMoreInteractions(changeEventsObserver);
         
         property2.setValue(20);
-        verify(changeEventsObserver2).onNext(new PropertyChangeEvent<>(10, 20, 3));
-        Mockito.verifyNoMoreInteractions(changeEventsObserver2);
+        verify(changeEventsObserver2).onNext(new PropertyChangeEvent<>(10, 20, 5));
+        verifyNoMoreInteractions(changeEventsObserver2);
         
         property.dispose();
         property2.dispose();
         verify(changeEventsObserver).onCompleted();
         verify(changeEventsObserver2).onCompleted();
+    }
+    
+    @Test
+    public void testUnsubscribePropertyChangeEvents() throws Exception {
+        Property<String> property = Property.create("tacos");
+        
+        Observer<PropertyChangeEvent<String>> changeEventsObserver = Mockito.mock(Observer.class);
+        Subscription subscription = property.getChangeEvents().subscribe(changeEventsObserver);
+        verifyNoMoreInteractions(changeEventsObserver);
+        
+        property.setValue("burritos");
+        verify(changeEventsObserver).onNext(new PropertyChangeEvent<>("tacos", "burritos", 1));
+        
+        // verify that unsubscribing and re-subscribing does not cancel the property changed event stream
+        subscription.unsubscribe();
+        Observer<PropertyChangeEvent<String>> changeEventsObserver2 = Mockito.mock(Observer.class);
+        property.getChangeEvents().subscribe(changeEventsObserver2);
+        verifyNoMoreInteractions(changeEventsObserver2);
+        
+        property.setValue("tacos");
+        verify(changeEventsObserver2).onNext(new PropertyChangeEvent<>("burritos", "tacos", 3));
     }
 }

--- a/src/test/java/mb/rxui/property/TestPropertyChangeEvents.java
+++ b/src/test/java/mb/rxui/property/TestPropertyChangeEvents.java
@@ -38,20 +38,20 @@ public class TestPropertyChangeEvents {
         
         // subscribing to property change events should not emit a change event until the value changes from the initial value.
         Observer<PropertyChangeEvent<String>> changeEventsObserver = Mockito.mock(Observer.class);
-        property.getChangeEvents().subscribe(changeEventsObserver);
+        property.changeEvents().subscribe(changeEventsObserver);
         verifyNoMoreInteractions(changeEventsObserver);
 
         // subscribing to property change events should not emit a change event until the value changes from the initial value.
         Observer<PropertyChangeEvent<Integer>> changeEventsObserver2 = Mockito.mock(Observer.class);
-        property2.getChangeEvents().subscribe(changeEventsObserver2);
+        property2.changeEvents().subscribe(changeEventsObserver2);
         verifyNoMoreInteractions(changeEventsObserver2);
         
         property.setValue("burritos");
-        verify(changeEventsObserver).onNext(new PropertyChangeEvent<>("tacos", "burritos", 4));
+        verify(changeEventsObserver).onNext(new PropertyChangeEvent<>("tacos", "burritos", 2));
         verifyNoMoreInteractions(changeEventsObserver);
         
         property2.setValue(20);
-        verify(changeEventsObserver2).onNext(new PropertyChangeEvent<>(10, 20, 5));
+        verify(changeEventsObserver2).onNext(new PropertyChangeEvent<>(10, 20, 3));
         verifyNoMoreInteractions(changeEventsObserver2);
         
         property.dispose();
@@ -65,7 +65,7 @@ public class TestPropertyChangeEvents {
         Property<String> property = Property.create("tacos");
         
         Observer<PropertyChangeEvent<String>> changeEventsObserver = Mockito.mock(Observer.class);
-        Subscription subscription = property.getChangeEvents().subscribe(changeEventsObserver);
+        Subscription subscription = property.changeEvents().subscribe(changeEventsObserver);
         verifyNoMoreInteractions(changeEventsObserver);
         
         property.setValue("burritos");
@@ -74,7 +74,7 @@ public class TestPropertyChangeEvents {
         // verify that unsubscribing and re-subscribing does not cancel the property changed event stream
         subscription.unsubscribe();
         Observer<PropertyChangeEvent<String>> changeEventsObserver2 = Mockito.mock(Observer.class);
-        property.getChangeEvents().subscribe(changeEventsObserver2);
+        property.changeEvents().subscribe(changeEventsObserver2);
         verifyNoMoreInteractions(changeEventsObserver2);
         
         property.setValue("tacos");

--- a/src/test/java/mb/rxui/property/publisher/TestMergePublisher.java
+++ b/src/test/java/mb/rxui/property/publisher/TestMergePublisher.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2015 Mike Baum
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package mb.rxui.property.publisher;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import mb.rxui.property.Property;
+import mb.rxui.property.PropertyObservable;
+import mb.rxui.property.PropertyObserver;
+import mb.rxui.property.Subscription;
+
+public class TestMergePublisher {
+    @Test
+    public void testMergePropertyObservables() throws Exception {
+        Property<String> property1 = Property.create("tacos");
+        Property<String> property2 = Property.create("burritos");
+        Property<String> property3 = Property.create("fajitas");
+        
+        PropertyObservable<String> mergedProperty = PropertyObservable.merge(property1, property2, property3);
+        
+        PropertyObserver<String> observer = mock(PropertyObserver.class);
+        InOrder inOrder = Mockito.inOrder(observer);
+        
+        // assert the dispatched values when subscribing
+        mergedProperty.observe(observer);
+        inOrder.verify(observer).onChanged("tacos");
+        inOrder.verify(observer).onChanged("burritos");
+        inOrder.verify(observer).onChanged("fajitas");
+        inOrder.verifyNoMoreInteractions();
+        
+        // assert that the merged property reflects the last value changed
+        property1.setValue("burritos");
+        assertEquals("burritos", mergedProperty.get());
+        inOrder.verify(observer).onChanged("burritos");
+        inOrder.verifyNoMoreInteractions();
+        
+        property2.setValue("fajitas");
+        assertEquals("fajitas", mergedProperty.get());
+        inOrder.verify(observer).onChanged("fajitas");
+        inOrder.verifyNoMoreInteractions();
+        
+        property3.setValue("tacos");
+        assertEquals("tacos", mergedProperty.get());
+        inOrder.verify(observer).onChanged("tacos");
+        inOrder.verifyNoMoreInteractions();
+        
+        // assert changing the value of one of the properties to the current value of the merged property does not dispatch.
+        property1.setValue("tacos");
+        property2.setValue("tacos");
+        assertEquals("tacos", mergedProperty.get());
+        inOrder.verifyNoMoreInteractions();
+    }
+    
+    @Test
+    public void testDisposeMergedProperties() throws Exception {
+        Property<String> property1 = Property.create("tacos");
+        Property<String> property2 = Property.create("burritos");
+        Property<String> property3 = Property.create("fajitas");
+        
+        PropertyObservable<String> mergedProperty = PropertyObservable.merge(property1, property2, property3);
+        
+        PropertyObserver<String> observer = mock(PropertyObserver.class);
+        InOrder inOrder = Mockito.inOrder(observer);
+        
+        // assert the dispatched values when subscribing
+        Subscription subscription = mergedProperty.observe(observer);
+        inOrder.verify(observer).onChanged("tacos");
+        inOrder.verify(observer).onChanged("burritos");
+        inOrder.verify(observer).onChanged("fajitas");
+        inOrder.verifyNoMoreInteractions();
+        
+        property1.dispose();
+        inOrder.verifyNoMoreInteractions();
+        
+        property2.dispose();
+        inOrder.verifyNoMoreInteractions();
+        
+        // disposing the last property should dispose the merged property
+        assertFalse(subscription.isDisposed());
+        property3.dispose();
+        inOrder.verify(observer).onDisposed();
+        assertTrue(subscription.isDisposed());
+    }
+    
+    @Test
+    public void testUnsubscribeDisposesAllMergeSubscriptions() throws Exception {
+        Property<String> property1 = Property.create("tacos");
+        Property<String> property2 = Property.create("burritos");
+        Property<String> property3 = Property.create("fajitas");
+        
+        PropertyObservable<String> mergedProperty = PropertyObservable.merge(property1, property2, property3);
+        
+        PropertyObserver<String> observer = mock(PropertyObserver.class);
+        
+        assertFalse(property1.hasObservers());
+        assertFalse(property2.hasObservers());
+        assertFalse(property3.hasObservers());
+        
+        Subscription subscription = mergedProperty.observe(observer);
+        
+        assertTrue(property1.hasObservers());
+        assertTrue(property2.hasObservers());
+        assertTrue(property3.hasObservers());
+        
+        // dispose the subscription and assert that the properties no longer have any observers
+        subscription.dispose();
+        assertFalse(property1.hasObservers());
+        assertFalse(property2.hasObservers());
+        assertFalse(property3.hasObservers());
+    }
+}


### PR DESCRIPTION
This PR implements the fix for adding a `merge` operator as per Issue #19. It also naively addresses issue #22.

Atomic changes are handled by the following:
1. The `PropertyDispatcher` has been updated to sort all subscriptions to ensure that binding subscriptions are first. This guarantees that all property values are updated before any lifting. Since all lift operators use the `get()` method which directly calls backwards through the property chain eventually stopping at a `Property`, the values returned from `get()` will always be correct since all properties have updated their value first.
2. The combine operator has been updated to not emit duplicate values in a row.
