### PR TITLE
Updated Bindings to prevent glitches when binding an EventStream to a Property

### DIFF
--- a/src/main/java/mb/rxui/Observer.java
+++ b/src/main/java/mb/rxui/Observer.java
@@ -20,5 +20,9 @@ package mb.rxui;
  *            the type of data being observed
  */
 public interface Observer<T> {
-    // no methods, marker interface for now.
+    
+    /**
+     * @return true if this observer is represents a binding, false otherwise.
+     */
+    default boolean isBinding() { return false; };
 }

--- a/src/main/java/mb/rxui/dispatcher/AbstractDispatcher.java
+++ b/src/main/java/mb/rxui/dispatcher/AbstractDispatcher.java
@@ -33,9 +33,11 @@ public abstract class AbstractDispatcher<V, S extends Subscriber & Observer<V>, 
     private final Function<S, Consumer<V>> dispatchFunction;
     private final Function<S, Runnable> disposeFunction;
     private final Type type;
+    private final List<Runnable> pausedDisptaches;
 
     private boolean isDispatching = false;
     private boolean isDisposed = false;
+    private int pauseCount = 0;
     
     protected AbstractDispatcher(List<S> subscribers, 
                                  Function<S, Consumer<V>> dispatchFunction, 
@@ -46,6 +48,7 @@ public abstract class AbstractDispatcher<V, S extends Subscriber & Observer<V>, 
         this.dispatchFunction = requireNonNull(dispatchFunction);
         this.disposeFunction = requireNonNull(disposeFunction);
         this.type = requireNonNull(type);
+        this.pausedDisptaches = new ArrayList<>();
     }
     
     @Override
@@ -75,12 +78,28 @@ public abstract class AbstractDispatcher<V, S extends Subscriber & Observer<V>, 
     @Override
     public void dispatch(V newValue) {
         checkState(!isDisposed, "Dispatcher has been disposed, cannot dispatch: " + newValue);
-        new ArrayList<>(subscribers).stream().map(dispatchFunction).forEach(consumer -> consumer.accept(newValue));
+        dispatchOrQueue(createDisptachRunnable(newValue));
+    }
+
+    private Runnable createDisptachRunnable(V newValue) {
+        return () -> {
+            boolean isEventDispatcher = getType() == Dispatcher.Type.EVENT;
+            
+            if (isEventDispatcher)
+                Dispatchers.getInstance().pausePropertyDispatchers();
+            
+            new ArrayList<>(subscribers).stream()
+                                        .map(dispatchFunction)
+                                        .forEach(consumer -> consumer.accept(newValue));
+            
+            if(isEventDispatcher)
+                Dispatchers.getInstance().resumePropertyDispatchers();
+        };
     }
 
     @Override
     public void invoke(Runnable runnable) {
-        wrapRunnable(runnable).run();
+        dispatchOrQueue(wrapRunnable(runnable));
     }
 
     @Override
@@ -114,6 +133,24 @@ public abstract class AbstractDispatcher<V, S extends Subscriber & Observer<V>, 
     public Type getType() {
         return type;
     }
+    
+    boolean isPaused() {
+        return pauseCount > 0;
+    }
+    
+    void pause() {
+        pauseCount++;
+    }
+
+    void resume() {
+        pauseCount--;
+        
+        if (isPaused())
+            return;
+        
+        pausedDisptaches.forEach(Runnable::run);
+        pausedDisptaches.clear();
+    }
 
     /**
      * Ensures that when the runnable is running that the dispatch flag is
@@ -133,5 +170,13 @@ public abstract class AbstractDispatcher<V, S extends Subscriber & Observer<V>, 
                 isDispatching = false;
             }
         };
+    }
+    
+    private void dispatchOrQueue(Runnable disptchRunnable) {
+        if (isPaused()) {
+            pausedDisptaches.add(disptchRunnable);
+        } else {
+            disptchRunnable.run();
+        }
     }
 }

--- a/src/main/java/mb/rxui/dispatcher/Dispatcher.java
+++ b/src/main/java/mb/rxui/dispatcher/Dispatcher.java
@@ -43,15 +43,6 @@ public interface Dispatcher<V, S extends Subscriber, O extends Observer<V>> exte
     void dispatch(V newValue);
     
     /**
-     * Invokes the provided {@link Runnable} and ensures that when the runnable
-     * is running that the dispatch flag is turned on and then off when
-     * execution is finished.
-     * 
-     * @param runnable some runnable to invoke and flag "Dispatching" while being run.
-     */
-    void invoke(Runnable runnable);
-
-    /**
      * Adds some disposable to dispose when this dispatcher is disposed.
      * 
      * @param toDispose

--- a/src/main/java/mb/rxui/dispatcher/Dispatchers.java
+++ b/src/main/java/mb/rxui/dispatcher/Dispatchers.java
@@ -86,6 +86,14 @@ public class Dispatchers {
             dispatchStateRestoreList.forEach(Runnable::run);
         };
     }
+    
+    public boolean isDispatching() {
+        return dispatchers.keySet().stream().filter(Dispatcher::isDispatching).findAny().isPresent();
+    }
+    
+    public boolean isDispatchingBinding() {
+        return dispatchers.keySet().stream().filter(AbstractDispatcher::isDispatchingToBinding).findAny().isPresent();
+    }
 
     <M> PropertyDispatcher<M> createPropertyDispatcher() {
         return addDispatcher(propertyDispatcherFactory.create());

--- a/src/main/java/mb/rxui/dispatcher/EventDispatcher.java
+++ b/src/main/java/mb/rxui/dispatcher/EventDispatcher.java
@@ -82,12 +82,16 @@ public class EventDispatcher<V> extends AbstractDispatcher<V, EventSubscriber<V>
         return new EventObserver<V>() {
             @Override
             public void onEvent(V event) {
-                invoke(() -> observer.onEvent(event));
+                dispatchOrQueue(() -> {
+                    setDispatchingToBinding(observer.isBinding());
+                    observer.onEvent(event);
+                    setDispatchingToBinding(false);
+                });
             }
 
             @Override
             public void onCompleted() {
-                invoke(observer::onCompleted);
+                dispatchOrQueue(observer::onCompleted);
             }
 
             @Override

--- a/src/main/java/mb/rxui/dispatcher/PropertyDispatcher.java
+++ b/src/main/java/mb/rxui/dispatcher/PropertyDispatcher.java
@@ -57,12 +57,16 @@ public class PropertyDispatcher<M> extends AbstractDispatcher<M, PropertySubscri
         return new PropertyObserver<M>() {
             @Override
             public void onChanged(M newValue) {
-                invoke(() -> observer.onChanged(newValue));
+                dispatchOrQueue(() -> {
+                    setDispatchingToBinding(observer.isBinding());
+                    observer.onChanged(newValue);
+                    setDispatchingToBinding(false);
+                });
             }
 
             @Override
             public void onDisposed() {
-                invoke(observer::onDisposed);
+                dispatchOrQueue(observer::onDisposed);
             }
 
             @Override

--- a/src/main/java/mb/rxui/dispatcher/PropertyDispatcher.java
+++ b/src/main/java/mb/rxui/dispatcher/PropertyDispatcher.java
@@ -30,7 +30,7 @@ import mb.rxui.property.PropertySubscriber;
 public class PropertyDispatcher<M> extends AbstractDispatcher<M, PropertySubscriber<M>, PropertyObserver<M>> {
 
     private final List<PropertySubscriber<M>> subscribers;
-    private static Comparator<? super PropertySubscriber<?>> SUBSCRIBER_COMPARATOR = createComparator();
+    private static final Comparator<? super PropertySubscriber<?>> SUBSCRIBER_COMPARATOR = createComparator();
     
     private PropertyDispatcher(List<PropertySubscriber<M>> subscribers) {
         super(subscribers, subscriber -> subscriber::onChanged, subscriber -> subscriber::onDisposed, PROPERTY);

--- a/src/main/java/mb/rxui/event/EventBinding.java
+++ b/src/main/java/mb/rxui/event/EventBinding.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2015 Mike Baum
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package mb.rxui.event;
+
+import static java.util.Objects.requireNonNull;
+
+import mb.rxui.property.Property;
+
+/**
+ * An Event Binding is a special type of Event Observer that represents an
+ * observer that binds an event stream to a property. When dispatching events
+ * event bindings are processed last, this guarantees that all stream observers
+ * are notified and up to date before processing any [event stream --> property]
+ * event propagation. 
+ * The reasoning behind this is that it should help to remove glitches and
+ * redundant updates. See <a href="http://stackoverflow.com/a/25141234">glich
+ * description</a>.
+ *
+ * @param <E>
+ *            the type of data observed by this observer.
+ */
+public class EventBinding<E> implements EventObserver<E> {
+
+    private final Property<E> boundProperty;
+
+    public EventBinding(Property<E> boundProperty) {
+        this.boundProperty = requireNonNull(boundProperty);
+    }
+    
+    @Override
+    public void onEvent(E event) {
+        boundProperty.setValue(event);
+    }
+
+    @Override
+    public void onCompleted() {
+        // nothing to do, we don't need to dispose a property when a source stream closes
+    }
+
+    @Override
+    public boolean isBinding() {
+        return true;
+    }
+}

--- a/src/main/java/mb/rxui/event/EventStream.java
+++ b/src/main/java/mb/rxui/event/EventStream.java
@@ -20,8 +20,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import mb.rxui.Subscription;
 import mb.rxui.EventLoop;
+import mb.rxui.Subscription;
 import mb.rxui.event.operator.Operator;
 import mb.rxui.event.operator.OperatorDebounce;
 import mb.rxui.event.operator.OperatorFilter;
@@ -184,20 +184,9 @@ public class EventStream<E> {
      */
     public final Property<E> toProperty(E initialValue) {
         
-        /**
-         * TODO: This needs work. The following things need to be done:
-         * <p>
-         * 1) If the event stream source is completed the subscription needs to
-         * be terminated
-         * <p>
-         * 2) Consider creating a Binding observer like has been done for
-         * properties. It might be necessary to process bindings before other
-         * observers in order to prevent glitches.
-         */
-        
         Property<E> property = Property.create(initialValue);
         
-        Subscription subscription = onEvent(property::setValue);
+        Subscription subscription = property.bind(this);
         property.onDisposed(subscription::dispose);
         
         return property;

--- a/src/main/java/mb/rxui/event/EventSubscriber.java
+++ b/src/main/java/mb/rxui/event/EventSubscriber.java
@@ -56,4 +56,9 @@ public class EventSubscriber<E> extends Subscriber implements EventObserver<E>, 
         runSafeCallback(observer::onCompleted);
         dispose();
     }
+
+    @Override
+    public boolean isBinding() {
+        return observer.isBinding();
+    }
 }

--- a/src/main/java/mb/rxui/property/Property.java
+++ b/src/main/java/mb/rxui/property/Property.java
@@ -14,6 +14,7 @@
 package mb.rxui.property;
 
 import static java.util.Objects.requireNonNull;
+import static mb.rxui.Preconditions.checkState;
 import static mb.rxui.dispatcher.Dispatcher.createPropertyDispatcher;
 
 import java.util.Optional;
@@ -21,8 +22,10 @@ import java.util.Optional;
 import javax.security.auth.Subject;
 
 import mb.rxui.Subscription;
+import mb.rxui.dispatcher.Dispatchers;
 import mb.rxui.dispatcher.PropertyDispatcher;
 import mb.rxui.EventLoop;
+import mb.rxui.Preconditions;
 import mb.rxui.disposables.Disposable;
 import mb.rxui.event.EventBinding;
 import mb.rxui.event.EventStream;
@@ -91,6 +94,9 @@ public final class Property<M> extends PropertyStream<M> implements PropertySour
         changeEvents.dispose();
     }
 
+    /**
+     * @throws IllegalStateException see {@link #checkCanSetValue()}
+     */
     @Override
     public void setValue(M value) {
         eventLoop.checkInEventLoop();
@@ -107,11 +113,33 @@ public final class Property<M> extends PropertyStream<M> implements PropertySour
         if (get().equals(value))
             return;
         
+        // blows up with an illegal state exception if an attempt is made to set the value via a non-binding callback.
+        checkCanSetValue();
+        
         M oldValue = get();
         propertySource.setValue(requireNonNull(value));
         // TODO: This call can be reentrant.
         changeEvents.publish(new PropertyChangeEvent<M>(oldValue, value));
 //        dispatcher.invoke(() -> changeEvents.publish(new PropertyChangeEvent<M>(oldValue, value)));
+    }
+
+    /**
+     * Checks whether the setValue call can be dispatched safely. It is only
+     * safe to set the value of this property within a Binding. Failing to
+     * respect this invariant would subvert the glitch protection that has been
+     * put in place.
+     * 
+     * @throws IllegalStateException
+     *             if an attempt was made to set the value from a callback,
+     *             other than a binding.
+     */
+    private void checkCanSetValue() {
+        boolean isNotDispatching = ! Dispatchers.getInstance().isDispatching();
+        boolean isDispatchingToBinding = Dispatchers.getInstance().isDispatchingBinding();
+        
+        checkState(isNotDispatching || isDispatchingToBinding, 
+                   "It is not possible to add a callback that sets the value of a property. " + 
+                   "You must use bind to connect a stream to this property");
     }
 
     /**

--- a/src/main/java/mb/rxui/property/PropertyBinding.java
+++ b/src/main/java/mb/rxui/property/PropertyBinding.java
@@ -14,22 +14,22 @@
 package mb.rxui.property;
 
 /**
- * A Binding is a special type of Property Observer that represents an observer
- * that binds one property to another. When dispatching events property bindings
- * are processed first, this guarantees that all properties have the up to date
- * value instantly at the same time before any other observers receive updates.
- * The reasoning behind this is that it should help to remove glitches and
- * redundant updates. See <a href="http://stackoverflow.com/a/25141234">glich
- * description</a>.
+ * A Property Binding is a special type of Property Observer that represents an
+ * observer that binds one property to another. When dispatching events property
+ * bindings are processed first, this guarantees that all properties have the up
+ * to date value instantly at the same time before any other observers receive
+ * updates. The reasoning behind this is that it should help to remove glitches
+ * and redundant updates. See
+ * <a href="http://stackoverflow.com/a/25141234">glich description</a>.
  *
  * @param <M>
  *            the type of data observed by this observer.
  */
-public class Binding<M> implements PropertyObserver<M> {
+public class PropertyBinding<M> implements PropertyObserver<M> {
     
     private final Property<M> boundProperty;
     
-    public Binding(Property<M> boundProperty) {
+    public PropertyBinding(Property<M> boundProperty) {
         this.boundProperty = boundProperty;
     }
 

--- a/src/main/java/mb/rxui/property/PropertyObserver.java
+++ b/src/main/java/mb/rxui/property/PropertyObserver.java
@@ -39,11 +39,6 @@ public interface PropertyObserver<M> extends Observer<M> {
      */
     void onDisposed();
     
-    /**
-     * @return true if this observer is represents a binding, false otherwise.
-     */
-    boolean isBinding();
-    
     // Factory methods
 
     /**
@@ -89,11 +84,6 @@ public interface PropertyObserver<M> extends Observer<M> {
             @Override
             public void onDisposed() {
                 onDisposed.run();
-            }
-            
-            @Override
-            public boolean isBinding() {
-                return false;
             }
         };
     }

--- a/src/test/java/mb/rxui/dispatcher/TestDispatchers.java
+++ b/src/test/java/mb/rxui/dispatcher/TestDispatchers.java
@@ -13,6 +13,8 @@
  */
 package mb.rxui.dispatcher;
 
+import static org.junit.Assert.*;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,6 +24,7 @@ import org.mockito.Mockito;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.dispatcher.Dispatchers.EventDispatcherFactory;
 import mb.rxui.dispatcher.Dispatchers.PropertyDispatcherFactory;
+import mb.rxui.property.Property;
 
 @RunWith(SwingTestRunner.class)
 public class TestDispatchers {
@@ -78,5 +81,52 @@ public class TestDispatchers {
         Assert.assertFalse(propertyDispatcher2.isDispatching());
         Assert.assertFalse(propertyDispatcher3.isDispatching());
         Assert.assertFalse(propertyDispatcher4.isDispatching());
+    }
+    
+    @Test
+    public void testIsDispatching() {
+        Dispatchers dispatchers = Dispatchers.getInstance();
+
+        Property<String> property1 = Property.create("one");
+        Property<String> property2 = Property.create("two");
+
+        // check during property1 dispatch that dispatchers isDispatching == true and isDispatchingBinding == false
+        property1.onChanged(value -> assertTrue(dispatchers.isDispatching()));
+        property1.onChanged(value -> assertFalse(dispatchers.isDispatchingBinding()));
+        
+        // check when not dispatching that isDispatching == false and isDispatchingBinding == false
+        assertFalse(dispatchers.isDispatching());
+        assertFalse(dispatchers.isDispatchingBinding());
+        
+        // check during property1 dispatch that dispatchers isDispatching == true
+        property2.onChanged(value -> assertTrue(dispatchers.isDispatching()));
+        
+        // check when not dispatching that isDispatching == false and isDispatchingBinding == false
+        assertFalse(dispatchers.isDispatching());
+        assertFalse(dispatchers.isDispatchingBinding());
+    }
+    
+    @Test
+    public void testIsDispatchingBinding() {
+        Dispatchers dispatchers = Dispatchers.getInstance();
+
+        Property<String> property1 = Property.create("one");
+        Property<String> property2 = Property.create("two");
+        
+        property1.bind(property2);
+        
+        // check during property1 dispatch that dispatchers isDispatching == true and isDispatchingBinding == true
+        property1.onChanged(value -> assertTrue(dispatchers.isDispatchingBinding()));
+        property1.onChanged(value -> assertTrue(dispatchers.isDispatching()));
+        
+        // check when not dispatching that isDispatching == false and isDispatchingBinding == false
+        assertFalse(dispatchers.isDispatching());
+        assertFalse(dispatchers.isDispatchingBinding());
+        
+        property2.setValue("three");
+        
+        // check when not dispatching that isDispatching == false and isDispatchingBinding == false
+        assertFalse(dispatchers.isDispatching());
+        assertFalse(dispatchers.isDispatchingBinding());
     }
 }

--- a/src/test/java/mb/rxui/event/TestEventStream.java
+++ b/src/test/java/mb/rxui/event/TestEventStream.java
@@ -14,10 +14,7 @@
 package mb.rxui.event;
 
 import static mb.rxui.ThreadedTestHelper.callOnIoThread;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 import java.util.function.Consumer;

--- a/src/test/java/mb/rxui/property/TestBinding.java
+++ b/src/test/java/mb/rxui/property/TestBinding.java
@@ -32,7 +32,7 @@ public class TestBinding {
         property.observe(observer);
         verify(observer).onChanged("tacos");
         
-        PropertyObserver<String> binding = new Binding<>(property);
+        PropertyObserver<String> binding = new PropertyBinding<>(property);
         assertTrue(binding.isBinding());
         
         binding.onChanged("burritos");

--- a/src/test/java/mb/rxui/property/TestBinding.java
+++ b/src/test/java/mb/rxui/property/TestBinding.java
@@ -14,6 +14,7 @@
 package mb.rxui.property;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
 import org.junit.Test;
@@ -39,6 +40,7 @@ public class TestBinding {
         verify(observer).onChanged("burritos");
         
         binding.onDisposed();
+        Mockito.verify(observer, atLeastOnce()).isBinding();
         Mockito.verifyNoMoreInteractions(observer);
     }
 }

--- a/src/test/java/mb/rxui/property/TestGlitchFree.java
+++ b/src/test/java/mb/rxui/property/TestGlitchFree.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2015 Mike Baum
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package mb.rxui.property;
+
+import static mb.rxui.property.PropertyStream.combine;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.function.Consumer;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import mb.rxui.SwingTestRunner;
+import mb.rxui.event.EventSubject;
+
+@RunWith(SwingTestRunner.class)
+public class TestGlitchFree {
+    
+    @Test
+    public void testNoGlitchFromEventStream() {
+        EventSubject<Integer> integers = EventSubject.create();
+        Property<Integer> property1 = Property.create(0);
+        Property<Integer> property2 = Property.create(0);
+        
+        property1.bind(integers);
+        property2.bind(integers);
+        
+        PropertyStream<Integer> combinedProperty = 
+                Property.combine(property1, property2, (a, b) -> a + b);
+        
+        Consumer<Integer> consumer = Mockito.mock(Consumer.class);
+        combinedProperty.onChanged(consumer);
+        
+        verify(consumer).accept(0);
+        
+        integers.publish(2);
+
+        // Assert that no '2' change was notified, since that would be a glitch.
+        verify(consumer).accept(4);
+        verifyNoMoreInteractions(consumer);
+    }
+    
+    @Test
+    public void testNoGlitchFromProperties() {
+        Property<Integer> property = Property.create(0);
+        
+        PropertyStream<Integer> propertyTimes2 = property.map(value -> value * 2);
+        PropertyStream<Integer> propertyTimes4 = property.map(value -> value * 4);
+        
+        PropertyStream<Integer> combinedProperty = combine(propertyTimes2, propertyTimes4, (a, b) -> a + b);
+        
+        Consumer<Integer> consumer = Mockito.mock(Consumer.class);
+        InOrder inOrder = Mockito.inOrder(consumer);
+
+        combinedProperty.onChanged(consumer);
+        
+        inOrder.verify(consumer).accept(0);
+        
+        property.setValue(2);
+        
+        // Assert that no '2' change was notified, since that would be a glitch.
+        inOrder.verify(consumer).accept(12);
+        inOrder.verifyNoMoreInteractions();
+    }
+    
+    @Test
+    public void testNoGlitchThroughPropertyBinding() {
+        Property<Integer> sourceProperty = Property.create(0);
+        Property<Integer> property = Property.create(0);
+        Property<Integer> property2 = Property.create(0);
+        
+        property.bind(sourceProperty);
+        property2.bind(sourceProperty);
+        
+        PropertyStream<Integer> combinedProperty = combine(property, property2, (a, b) -> a + b);
+        Consumer<Integer> consumer = Mockito.mock(Consumer.class);
+        InOrder inOrder = Mockito.inOrder(consumer);
+        
+        combinedProperty.onChanged(consumer);
+        inOrder.verify(consumer).accept(0);
+
+
+        PropertyStream<Integer> combinedTimes2 = combinedProperty.map(value -> value * 2);
+        Consumer<Integer> consumer2 = Mockito.mock(Consumer.class);
+        InOrder inOrder2 = Mockito.inOrder(consumer2);
+
+        combine(combinedTimes2, property, (a, b) -> a + b).onChanged(consumer2);
+        inOrder2.verify(consumer2).accept(0);
+        
+        
+        sourceProperty.setValue(2);
+        
+        // Assert that no '2' change was notified, since that would be a glitch.
+        inOrder.verify(consumer).accept(4);
+        inOrder.verifyNoMoreInteractions();
+        
+        inOrder2.verify(consumer2).accept(10);
+    }
+}

--- a/src/test/java/mb/rxui/property/TestModelPropertySource.java
+++ b/src/test/java/mb/rxui/property/TestModelPropertySource.java
@@ -14,6 +14,7 @@
 package mb.rxui.property;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.atLeastOnce;
 
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -36,6 +37,7 @@ public class TestModelPropertySource {
         source.setValue("burritos");
         assertEquals("burritos", source.get());
         Mockito.verify(observer).onChanged("burritos");
+        Mockito.verify(observer, atLeastOnce()).isBinding();
         Mockito.verifyNoMoreInteractions(observer);
     }
 }

--- a/src/test/java/mb/rxui/property/TestPropertyChangeEvents.java
+++ b/src/test/java/mb/rxui/property/TestPropertyChangeEvents.java
@@ -13,6 +13,7 @@
  */
 package mb.rxui.property;
 
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -51,10 +52,12 @@ public class TestPropertyChangeEvents {
         
         property.setValue("burritos");
         verify(changeEventsObserver).onEvent(new PropertyChangeEvent<>("tacos", "burritos", 0));
+        verify(changeEventsObserver, atLeastOnce()).isBinding();
         verifyNoMoreInteractions(changeEventsObserver);
         
         property2.setValue(20);
         verify(changeEventsObserver2).onEvent(new PropertyChangeEvent<>(10, 20, 1));
+        verify(changeEventsObserver2, atLeastOnce()).isBinding();
         verifyNoMoreInteractions(changeEventsObserver2);
         
         property.dispose();

--- a/src/test/java/mb/rxui/property/TestPropertySubscriber.java
+++ b/src/test/java/mb/rxui/property/TestPropertySubscriber.java
@@ -99,7 +99,7 @@ public class TestPropertySubscriber {
     
     @Test
     public void testBindingSubscriber() throws Exception {
-        Binding<String> binding = ThreadedTestHelper.createOnEDT(() -> new Binding<>(Property.create("tacos")));
+        PropertyBinding<String> binding = ThreadedTestHelper.createOnEDT(() -> new PropertyBinding<>(Property.create("tacos")));
         PropertySubscriber<String> propertySubscriber = new PropertySubscriber<>(binding);
         assertTrue(propertySubscriber.isBinding());
     }

--- a/src/test/java/mb/rxui/property/dispatcher/TestPropertyDispatcher.java
+++ b/src/test/java/mb/rxui/property/dispatcher/TestPropertyDispatcher.java
@@ -135,14 +135,12 @@ public class TestPropertyDispatcher {
         inOrder.verify(binding).onChanged("fajitas");
         inOrder.verify(onChanged).accept("fajitas");
         inOrder.verify(observer).onChanged("fajitas");
-        inOrder.verifyNoMoreInteractions();
         
         dispatcher.dispose();
         
         inOrder.verify(binding).onDisposed();
         inOrder.verify(onDisposed).run();
         inOrder.verify(observer).onDisposed();
-        inOrder.verifyNoMoreInteractions();
     }
     
     @Test
@@ -164,6 +162,5 @@ public class TestPropertyDispatcher {
         inOrder.verify(binding2).onChanged("tacos");
         inOrder.verify(onChanged).accept("tacos");
         inOrder.verify(observer).onChanged("tacos");
-        inOrder.verifyNoMoreInteractions();
     }
 }

--- a/src/test/java/mb/rxui/property/dispatcher/TestPropertyDispatcher.java
+++ b/src/test/java/mb/rxui/property/dispatcher/TestPropertyDispatcher.java
@@ -30,7 +30,7 @@ import mb.rxui.SwingTestRunner;
 import mb.rxui.dispatcher.Dispatcher;
 import mb.rxui.dispatcher.PropertyDispatcher;
 import mb.rxui.disposables.Disposable;
-import mb.rxui.property.Binding;
+import mb.rxui.property.PropertyBinding;
 import mb.rxui.property.Property;
 import mb.rxui.property.PropertyObserver;
 
@@ -121,7 +121,7 @@ public class TestPropertyDispatcher {
     
     @Test
     public void testBindingsDispatchedFirst() throws Exception {
-        Binding<String> binding = Mockito.spy(new Binding<>(Property.create("burritos")));
+        PropertyBinding<String> binding = Mockito.spy(new PropertyBinding<>(Property.create("burritos")));
         dispatcher.subscribe(binding);
         
         PropertyObserver<String> observer = Mockito.mock(PropertyObserver.class);
@@ -147,13 +147,13 @@ public class TestPropertyDispatcher {
     
     @Test
     public void testOrderOfBindingsSameAsAdded() throws Exception {
-        Binding<String> binding1 = Mockito.spy(new Binding<>(Property.create("burritos")));
+        PropertyBinding<String> binding1 = Mockito.spy(new PropertyBinding<>(Property.create("burritos")));
         dispatcher.subscribe(binding1);
         
         PropertyObserver<String> observer = Mockito.mock(PropertyObserver.class);
         dispatcher.subscribe(observer);
         
-        Binding<String> binding2 = Mockito.spy(new Binding<>(Property.create("burritos")));
+        PropertyBinding<String> binding2 = Mockito.spy(new PropertyBinding<>(Property.create("burritos")));
         dispatcher.subscribe(binding2);
         
         InOrder inOrder = Mockito.inOrder(onChanged, observer, binding1, binding2);


### PR DESCRIPTION
This PR fixes Issue #34.

High Level Changes:
1. Prevent propagating Property subscribers while dispatching an event from an EventStream, by pausing and resuming all properties during dispatch.
2. Ensure that Event Bindings are processed last during event dispatch.
3. Block the ability to set a value of a property from callbacks other than bindings.
