### PR TITLE
Added a switchMap method to EventStream.

### DIFF
--- a/src/main/java/mb/rxui/Publisher.java
+++ b/src/main/java/mb/rxui/Publisher.java
@@ -14,6 +14,7 @@
 package mb.rxui;
 
 import mb.rxui.property.PropertySubscriber;
+import mb.rxui.subscription.Subscription;
 
 /**
  * A publisher is some class that can publish values and can be subscribed to.

--- a/src/main/java/mb/rxui/Subscriber.java
+++ b/src/main/java/mb/rxui/Subscriber.java
@@ -16,6 +16,8 @@ package mb.rxui;
 import java.util.ArrayList;
 import java.util.List;
 
+import mb.rxui.subscription.Subscription;
+
 public abstract class Subscriber implements Subscription {
 
     private final List<Runnable> onDisposedActions;

--- a/src/main/java/mb/rxui/dispatcher/EventDispatcher.java
+++ b/src/main/java/mb/rxui/dispatcher/EventDispatcher.java
@@ -66,6 +66,9 @@ public class EventDispatcher<V> extends AbstractDispatcher<V, EventSubscriber<V>
         
         EventSubscriber<V> subscriber = new EventSubscriber<>(wrapObserver(observer));
         
+        if (observer instanceof EventSubscriber)
+            subscriber.doOnDispose(((EventSubscriber<V>)observer)::dispose);
+        
         if(isDisposed()) {
             subscriber.onCompleted();
             return subscriber;

--- a/src/main/java/mb/rxui/event/EventStream.java
+++ b/src/main/java/mb/rxui/event/EventStream.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import mb.rxui.EventLoop;
-import mb.rxui.Subscription;
 import mb.rxui.event.operator.Operator;
 import mb.rxui.event.operator.OperatorChanges;
 import mb.rxui.event.operator.OperatorDebounce;
@@ -38,11 +37,13 @@ import mb.rxui.event.operator.OperatorFilter;
 import mb.rxui.event.operator.OperatorMap;
 import mb.rxui.event.operator.OperatorScan;
 import mb.rxui.event.operator.OperatorScanOptional;
+import mb.rxui.event.operator.OperatorSwitchMap;
 import mb.rxui.event.publisher.EventPublisher;
 import mb.rxui.event.publisher.FlattenPublisher;
 import mb.rxui.event.publisher.LiftEventPublisher;
 import mb.rxui.event.publisher.MergeEventPublisher;
 import mb.rxui.property.Property;
+import mb.rxui.subscription.Subscription;
 import rx.Observable;
 import rx.Subscriber;
 import rx.subscriptions.Subscriptions;
@@ -293,6 +294,27 @@ public class EventStream<E> {
         streamList.add(this);
         
         return EventStream.merge(streamList);
+    }
+
+    /**
+     * Creates a new stream that can switch the output stream by the provided
+     * switchFunction. Visually, this is roughly equivalent to the following:
+     * <br>
+     *                    _________________________________
+     *                   |       switchFunction            | 
+     *                   | [stream 1] -->                  |
+     * [this stream] --> | [stream 2] --> switches between | --> [stream 1 | stream 2 | stream 3]
+     *                   | [stream 3] -->     streams      |
+     *                   |_________________________________|
+     * <br>
+     * @param switchFunction
+     *            function that can be used to switch between a set of source
+     *            streams.
+     * @return a new stream that uses the provided switchFunction to switch
+     *         between a set of source streams.
+     */
+    public final <R> EventStream<R> switchMap(Function<E, EventStream<R>> switchFunction) {
+        return lift(new OperatorSwitchMap<>(switchFunction));
     }
     
     /**

--- a/src/main/java/mb/rxui/event/EventSubject.java
+++ b/src/main/java/mb/rxui/event/EventSubject.java
@@ -16,11 +16,11 @@ package mb.rxui.event;
 import static java.util.Objects.requireNonNull;
 
 import mb.rxui.EventLoop;
-import mb.rxui.Subscription;
 import mb.rxui.dispatcher.Dispatcher;
 import mb.rxui.dispatcher.EventDispatcher;
 import mb.rxui.disposables.Disposable;
 import mb.rxui.event.publisher.EventPublisher;
+import mb.rxui.subscription.Subscription;
 
 /**
  * An instance of an {@link EventStream} that is also an {@link EventSource} and can

--- a/src/main/java/mb/rxui/event/EventSubscriber.java
+++ b/src/main/java/mb/rxui/event/EventSubscriber.java
@@ -17,7 +17,7 @@ import static java.util.Objects.requireNonNull;
 import static mb.rxui.Callbacks.runSafeCallback;
 
 import mb.rxui.Subscriber;
-import mb.rxui.Subscription;
+import mb.rxui.subscription.Subscription;
 
 /**
  * A subscriber used when subscribing to an {@link EventStream}.
@@ -38,6 +38,11 @@ public class EventSubscriber<E> extends Subscriber implements EventObserver<E>, 
     
     public EventSubscriber(EventObserver<E> observer) {
         this.observer = requireNonNull(observer);
+    }
+    
+    public EventSubscriber(EventSubscriber<E> subscriber) {
+        this.observer = subscriber;
+        doOnDispose(subscriber::dispose);
     }
     
     @Override

--- a/src/main/java/mb/rxui/event/operator/OperatorChanges.java
+++ b/src/main/java/mb/rxui/event/operator/OperatorChanges.java
@@ -49,11 +49,7 @@ public class OperatorChanges<E, C> implements Operator<E, C> {
                 EventObserver.create(value -> emitValueOrSetLast(lastValue, value, childSubscriber),
                                      childSubscriber::onCompleted);
         
-        EventSubscriber<E> subscriber = new EventSubscriber<>(sourceObserver);
-        
-        childSubscriber.doOnDispose(subscriber::dispose);
-        
-        return subscriber;
+        return new EventSubscriber<>(sourceObserver);
     }
     
     private void emitValueOrSetLast(AtomicReference<E> lastValue, E currentValue, EventSubscriber<C> subscriber) {

--- a/src/main/java/mb/rxui/event/operator/OperatorDebounce.java
+++ b/src/main/java/mb/rxui/event/operator/OperatorDebounce.java
@@ -55,10 +55,6 @@ public class OperatorDebounce<M> implements Operator<M, M> {
             childSubscriber.onCompleted();
         });
         
-        EventSubscriber<M> subscriber = new EventSubscriber<>(sourceObserver);
-        
-        childSubscriber.doOnDispose(subscriber::dispose);
-        
-        return subscriber;
+        return new EventSubscriber<>(sourceObserver);
     }
 }

--- a/src/main/java/mb/rxui/event/operator/OperatorFilter.java
+++ b/src/main/java/mb/rxui/event/operator/OperatorFilter.java
@@ -43,10 +43,6 @@ public final class OperatorFilter<T> implements Operator<T, T> {
                 childSubscriber.onEvent(value);
         } , childSubscriber::onCompleted);
 
-        EventSubscriber<T> subscriber = new EventSubscriber<>(sourceObserver);
-
-        childSubscriber.doOnDispose(subscriber::dispose);
-
-        return subscriber;
+        return new EventSubscriber<>(sourceObserver);
     }
 }

--- a/src/main/java/mb/rxui/event/operator/OperatorMap.java
+++ b/src/main/java/mb/rxui/event/operator/OperatorMap.java
@@ -44,10 +44,6 @@ public class OperatorMap<I, R> implements Operator<I, R> {
                 EventObserver.create(value -> childSubscriber.onEvent(mapper.apply(value)),
                                            childSubscriber::onCompleted);
         
-        EventSubscriber<I> subscriber = new EventSubscriber<>(sourceObserver);
-        
-        childSubscriber.doOnDispose(subscriber::dispose);
-        
-        return subscriber;
+        return new EventSubscriber<>(sourceObserver);
     }
 }

--- a/src/main/java/mb/rxui/event/operator/OperatorScan.java
+++ b/src/main/java/mb/rxui/event/operator/OperatorScan.java
@@ -53,10 +53,6 @@ public class OperatorScan<E, R> implements Operator<E, R> {
                                      },
                                      childSubscriber::onCompleted);
         
-        EventSubscriber<E> subscriber = new EventSubscriber<>(sourceObserver);
-        
-        childSubscriber.doOnDispose(subscriber::dispose);
-        
-        return subscriber;
+        return new EventSubscriber<>(sourceObserver);
     }
 }

--- a/src/main/java/mb/rxui/event/operator/OperatorScanOptional.java
+++ b/src/main/java/mb/rxui/event/operator/OperatorScanOptional.java
@@ -48,10 +48,6 @@ public class OperatorScanOptional<E, R> implements Operator<E, R> {
                                      },
                                      childSubscriber::onCompleted);
         
-        EventSubscriber<E> subscriber = new EventSubscriber<>(sourceObserver);
-        
-        childSubscriber.doOnDispose(subscriber::dispose);
-        
-        return subscriber;
+        return new EventSubscriber<>(sourceObserver);
     }
 }

--- a/src/main/java/mb/rxui/event/operator/OperatorSwitchMap.java
+++ b/src/main/java/mb/rxui/event/operator/OperatorSwitchMap.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015 Mike Baum
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package mb.rxui.event.operator;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
+import mb.rxui.event.EventObserver;
+import mb.rxui.event.EventStream;
+import mb.rxui.event.EventSubscriber;
+import mb.rxui.subscription.RollingSubscription;
+
+/**
+ * {@link OperatorSwitchMap} transforms a stream by switching between streams to
+ * emit based on the switch function. <br>
+ * <br>
+ * In other words the switch function will produce a new stream for any value of
+ * the source stream. This new stream will be connected to the downstream
+ * subscriber. This is really like a switch for streams.
+ * 
+ * 
+ * @param <E>
+ *            the type of the events emitted by the source stream
+ * @param <R>
+ *            the type of the stream created by the switch function
+ */
+public class OperatorSwitchMap<E, R> implements Operator<E, R>{
+    
+    private final Function<E, EventStream<R>> switchFunction;
+    
+    public OperatorSwitchMap(Function<E, EventStream<R>> switchFunction) {
+        this.switchFunction = requireNonNull(switchFunction);
+    }
+    
+    @Override
+    public EventSubscriber<E> apply(EventSubscriber<R> childSubscriber) {
+
+        RollingSubscription streamSubscription = new RollingSubscription();
+        
+        EventObserver<E> sourceObserver = 
+                EventObserver.create(event -> streamSubscription.set(switchFunction.apply(event).onEvent(childSubscriber::onEvent)),
+                                     childSubscriber::onCompleted);
+        
+        childSubscriber.doOnDispose(streamSubscription::dispose);
+        
+        return new EventSubscriber<>(sourceObserver);
+    }
+}

--- a/src/main/java/mb/rxui/event/publisher/FlattenPublisher.java
+++ b/src/main/java/mb/rxui/event/publisher/FlattenPublisher.java
@@ -15,11 +15,11 @@ package mb.rxui.event.publisher;
 
 import static java.util.Objects.requireNonNull;
 
-import mb.rxui.Subscription;
 import mb.rxui.event.EventObserver;
 import mb.rxui.event.EventStream;
 import mb.rxui.event.EventSubscriber;
-import mb.rxui.property.CompositeSubscription;
+import mb.rxui.subscription.CompositeSubscription;
+import mb.rxui.subscription.Subscription;
 
 /**
  * A Flatten Publisher can flatten a nested stream of stream into a stream.
@@ -44,7 +44,7 @@ public class FlattenPublisher<E> implements EventPublisher<E> {
         
         Subscription streamSub = 
                 streamOfStreams.map(stream -> stream.onEvent(flattenSubscriber::onEvent))
-                               .observe(EventObserver.create(subscriptions::add, 
+                               .observe(EventObserver.create(subscriptions::add,
                                                              flattenSubscriber::onCompleted));
 
         subscriptions.add(streamSub);

--- a/src/main/java/mb/rxui/event/publisher/LiftEventPublisher.java
+++ b/src/main/java/mb/rxui/event/publisher/LiftEventPublisher.java
@@ -15,10 +15,10 @@ package mb.rxui.event.publisher;
 
 import static java.util.Objects.requireNonNull;
 
-import mb.rxui.Subscription;
 import mb.rxui.event.EventObserver;
 import mb.rxui.event.EventSubscriber;
 import mb.rxui.event.operator.Operator;
+import mb.rxui.subscription.Subscription;
 
 /**
  * An {@link EventPublisher} that is used to transform (lift) the emitted event
@@ -43,6 +43,12 @@ public class LiftEventPublisher<T, R> implements EventPublisher<R> {
     
     @Override
     public Subscription subscribe(EventObserver<R> observer) {
-        return sourcePublisher.subscribe(operator.apply(new EventSubscriber<>(observer)));
+        EventSubscriber<R> subscriber = new EventSubscriber<>(observer);
+        
+        Subscription subscription = sourcePublisher.subscribe(operator.apply(subscriber));
+        
+        subscriber.doOnDispose(subscription::dispose);
+        
+        return subscriber;
     }
 }

--- a/src/main/java/mb/rxui/event/publisher/MergeEventPublisher.java
+++ b/src/main/java/mb/rxui/event/publisher/MergeEventPublisher.java
@@ -20,11 +20,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import mb.rxui.Counter;
-import mb.rxui.Subscription;
 import mb.rxui.event.EventObserver;
 import mb.rxui.event.EventStream;
 import mb.rxui.event.EventSubscriber;
-import mb.rxui.property.CompositeSubscription;
+import mb.rxui.subscription.CompositeSubscription;
+import mb.rxui.subscription.Subscription;
 
 /**
  * A Publisher that merges many event streams into one stream.

--- a/src/main/java/mb/rxui/property/Property.java
+++ b/src/main/java/mb/rxui/property/Property.java
@@ -22,13 +22,14 @@ import java.util.Optional;
 import javax.security.auth.Subject;
 
 import mb.rxui.EventLoop;
-import mb.rxui.Subscription;
 import mb.rxui.dispatcher.Dispatchers;
 import mb.rxui.dispatcher.PropertyDispatcher;
 import mb.rxui.disposables.Disposable;
 import mb.rxui.event.EventBinding;
 import mb.rxui.event.EventStream;
 import mb.rxui.property.publisher.PropertyPublisher;
+import mb.rxui.subscription.CompositeSubscription;
+import mb.rxui.subscription.Subscription;
 import rx.subjects.BehaviorSubject;
 
 /**

--- a/src/main/java/mb/rxui/property/PropertyStream.java
+++ b/src/main/java/mb/rxui/property/PropertyStream.java
@@ -29,7 +29,6 @@ import java.util.function.Supplier;
 
 import mb.rxui.EventLoop;
 import mb.rxui.Preconditions;
-import mb.rxui.Subscription;
 import mb.rxui.event.EventStream;
 import mb.rxui.property.operator.OperatorFilterToOptional;
 import mb.rxui.property.operator.OperatorIsDirty;
@@ -39,6 +38,7 @@ import mb.rxui.property.operator.PropertyConditionBuilder;
 import mb.rxui.property.operator.PropertyOperator;
 import mb.rxui.property.publisher.CombinePropertyPublisher;
 import mb.rxui.property.publisher.PropertyPublisher;
+import mb.rxui.subscription.Subscription;
 import rx.Observable;
 import rx.subscriptions.Subscriptions;
 

--- a/src/main/java/mb/rxui/property/javafx/ObservableValuePropertyPublisher.java
+++ b/src/main/java/mb/rxui/property/javafx/ObservableValuePropertyPublisher.java
@@ -17,10 +17,10 @@ import static java.util.Objects.requireNonNull;
 
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
-import mb.rxui.Subscription;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.PropertySubscriber;
 import mb.rxui.property.publisher.PropertyPublisher;
+import mb.rxui.subscription.Subscription;
 
 public final class ObservableValuePropertyPublisher<T> implements PropertyPublisher<T> {
 

--- a/src/main/java/mb/rxui/property/operator/OperatorFilterToOptional.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorFilterToOptional.java
@@ -16,10 +16,10 @@ package mb.rxui.property.operator;
 import java.util.Optional;
 import java.util.function.Predicate;
 
-import mb.rxui.Subscription;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.PropertySubscriber;
 import mb.rxui.property.publisher.PropertyPublisher;
+import mb.rxui.subscription.Subscription;
 
 /**
  * Filters values based on some predicate. Emits an Optional empty if the

--- a/src/main/java/mb/rxui/property/operator/OperatorIs.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorIs.java
@@ -19,10 +19,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import mb.rxui.Subscription;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.PropertySubscriber;
 import mb.rxui.property.publisher.PropertyPublisher;
+import mb.rxui.subscription.Subscription;
 
 /**
  * A {@link PropertyOperator} that transforms the property stream into a

--- a/src/main/java/mb/rxui/property/operator/OperatorIsDirty.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorIsDirty.java
@@ -13,10 +13,10 @@
  */
 package mb.rxui.property.operator;
 
-import mb.rxui.Subscription;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.PropertySubscriber;
 import mb.rxui.property.publisher.PropertyPublisher;
+import mb.rxui.subscription.Subscription;
 
 public class OperatorIsDirty<M> implements PropertyOperator<M, Boolean> {
 

--- a/src/main/java/mb/rxui/property/operator/OperatorMap.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorMap.java
@@ -15,10 +15,10 @@ package mb.rxui.property.operator;
 
 import java.util.function.Function;
 
-import mb.rxui.Subscription;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.PropertySubscriber;
 import mb.rxui.property.publisher.PropertyPublisher;
+import mb.rxui.subscription.Subscription;
 
 public class OperatorMap<S, R> implements PropertyOperator<S, R>{
 

--- a/src/main/java/mb/rxui/property/operator/OperatorTake.java
+++ b/src/main/java/mb/rxui/property/operator/OperatorTake.java
@@ -13,11 +13,11 @@
  */
 package mb.rxui.property.operator;
 
-import mb.rxui.Subscription;
 import mb.rxui.property.PropertyStream;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.PropertySubscriber;
 import mb.rxui.property.publisher.PropertyPublisher;
+import mb.rxui.subscription.Subscription;
 
 /**
  * An operator that limits the number of values dispatched to subscribers.<br>

--- a/src/main/java/mb/rxui/property/operator/PropertyConditionBuilder.java
+++ b/src/main/java/mb/rxui/property/operator/PropertyConditionBuilder.java
@@ -19,8 +19,8 @@ import static mb.rxui.Functions.TRUE;
 import java.util.ArrayList;
 import java.util.List;
 
-import mb.rxui.Subscription;
 import mb.rxui.property.PropertyStream;
+import mb.rxui.subscription.Subscription;
 
 /**
  * A {@link PropertyConditionBuilder} can be used to setup some multi-condition

--- a/src/main/java/mb/rxui/property/publisher/CombinePropertyPublisher.java
+++ b/src/main/java/mb/rxui/property/publisher/CombinePropertyPublisher.java
@@ -20,11 +20,11 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import mb.rxui.Subscription;
-import mb.rxui.property.CompositeSubscription;
 import mb.rxui.property.PropertyStream;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.PropertySubscriber;
+import mb.rxui.subscription.CompositeSubscription;
+import mb.rxui.subscription.Subscription;
 
 /**
  * A {@link PropertyPublisher} that will combine the values of the provided

--- a/src/main/java/mb/rxui/property/publisher/PropertyPublisher.java
+++ b/src/main/java/mb/rxui/property/publisher/PropertyPublisher.java
@@ -16,10 +16,10 @@ package mb.rxui.property.publisher;
 import java.util.function.Supplier;
 
 import mb.rxui.Publisher;
-import mb.rxui.Subscription;
 import mb.rxui.dispatcher.PropertyDispatcher;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.PropertySubscriber;
+import mb.rxui.subscription.Subscription;
 
 /**
  * A {@link PropertyPublisher} represents some source of property updates.

--- a/src/main/java/mb/rxui/property/publisher/PropertyPublisherImpl.java
+++ b/src/main/java/mb/rxui/property/publisher/PropertyPublisherImpl.java
@@ -18,10 +18,10 @@ import static java.util.Objects.requireNonNull;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import mb.rxui.Subscription;
 import mb.rxui.dispatcher.PropertyDispatcher;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.PropertySubscriber;
+import mb.rxui.subscription.Subscription;
 
 /**
  * Default implementation of a property publisher.

--- a/src/main/java/mb/rxui/subscription/CompositeSubscription.java
+++ b/src/main/java/mb/rxui/subscription/CompositeSubscription.java
@@ -11,13 +11,12 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package mb.rxui.property;
+package mb.rxui.subscription;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import mb.rxui.Subscription;
 import mb.rxui.disposables.Disposable;
 
 public class CompositeSubscription implements Subscription {

--- a/src/main/java/mb/rxui/subscription/RollingSubscription.java
+++ b/src/main/java/mb/rxui/subscription/RollingSubscription.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2015 Mike Baum
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package mb.rxui.subscription;
+
+import java.util.Optional;
+
+/**
+ * A subscription that can be updated, via the method {@link #set(Subscription)}
+ * . When setting a new subscription the current one will be disposed.
+ */
+public class RollingSubscription implements Subscription {
+    
+    private Optional<Subscription> subscription = Optional.empty();
+    private boolean disposed = false;
+    
+    @Override
+    public void dispose() {
+        if(disposed)
+            return;
+        
+        disposed = true;
+        subscription.ifPresent(Subscription::dispose);
+    }
+
+    @Override
+    public boolean isDisposed() {
+        return disposed;
+    }
+    
+    /**
+     * Updates the subscription held by this rolling subscription. Disposes the
+     * existing subscription if present.
+     * 
+     * @param subscription
+     *            some subscription to set
+     */
+    public void set(Subscription subscription) {
+        if(disposed) {            
+            subscription.dispose();
+        } else {
+            this.subscription.ifPresent(Subscription::dispose);
+            this.subscription = Optional.of(subscription);
+        }
+    }
+}

--- a/src/main/java/mb/rxui/subscription/Subscription.java
+++ b/src/main/java/mb/rxui/subscription/Subscription.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package mb.rxui;
+package mb.rxui.subscription;
 
 import mb.rxui.disposables.Disposable;
 

--- a/src/test/java/mb/rxui/TestSubscription.java
+++ b/src/test/java/mb/rxui/TestSubscription.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import mb.rxui.disposables.Disposable;
+import mb.rxui.subscription.Subscription;
 
 public class TestSubscription {
     @Test

--- a/src/test/java/mb/rxui/event/TestEventStream.java
+++ b/src/test/java/mb/rxui/event/TestEventStream.java
@@ -28,10 +28,10 @@ import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.property.Property;
 import mb.rxui.property.PropertyObserver;
+import mb.rxui.subscription.Subscription;
 import rx.Notification;
 import rx.Observable;
 import rx.Observer;

--- a/src/test/java/mb/rxui/event/TestEventSubject.java
+++ b/src/test/java/mb/rxui/event/TestEventSubject.java
@@ -23,8 +23,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestEventSubject {

--- a/src/test/java/mb/rxui/event/operator/TestOperatorChanges.java
+++ b/src/test/java/mb/rxui/event/operator/TestOperatorChanges.java
@@ -25,11 +25,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.event.EventObserver;
 import mb.rxui.event.EventStream;
 import mb.rxui.event.EventSubject;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestOperatorChanges {

--- a/src/test/java/mb/rxui/event/operator/TestOperatorFilter.java
+++ b/src/test/java/mb/rxui/event/operator/TestOperatorFilter.java
@@ -24,11 +24,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.event.EventStream;
 import mb.rxui.event.EventObserver;
 import mb.rxui.event.EventSubject;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestOperatorFilter {

--- a/src/test/java/mb/rxui/event/operator/TestOperatorMap.java
+++ b/src/test/java/mb/rxui/event/operator/TestOperatorMap.java
@@ -24,11 +24,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.event.EventStream;
 import mb.rxui.event.EventObserver;
 import mb.rxui.event.EventSubject;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestOperatorMap {

--- a/src/test/java/mb/rxui/event/operator/TestOperatorScan.java
+++ b/src/test/java/mb/rxui/event/operator/TestOperatorScan.java
@@ -23,11 +23,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.event.EventObserver;
 import mb.rxui.event.EventStream;
 import mb.rxui.event.EventSubject;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestOperatorScan {

--- a/src/test/java/mb/rxui/event/operator/TestOperatorScanOptional.java
+++ b/src/test/java/mb/rxui/event/operator/TestOperatorScanOptional.java
@@ -23,11 +23,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.event.EventObserver;
 import mb.rxui.event.EventStream;
 import mb.rxui.event.EventSubject;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestOperatorScanOptional {

--- a/src/test/java/mb/rxui/event/operator/TestOperatorSwitchMap.java
+++ b/src/test/java/mb/rxui/event/operator/TestOperatorSwitchMap.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright 2015 Mike Baum
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package mb.rxui.event.operator;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+
+import javax.swing.SwingUtilities;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.LenientCopyTool;
+
+import mb.rxui.SwingTestRunner;
+import mb.rxui.event.EventObserver;
+import mb.rxui.event.EventStream;
+import mb.rxui.event.EventSubject;
+import mb.rxui.subscription.Subscription;
+
+@RunWith(SwingTestRunner.class)
+public class TestOperatorSwitchMap {
+    
+    private EventSubject<String> streamA;
+    private EventSubject<String> streamB;
+    private EventSubject<String> streamC;
+    private EventSubject<String> defaultStream;
+    private EventSubject<String> streamOfLetters;
+    private EventStream<String> switchMapStream;
+    
+    @Before
+    public void setup() throws Exception {
+        SwingUtilities.invokeAndWait(() -> {            
+            streamA = EventSubject.create();
+            streamB = EventSubject.create();
+            streamC = EventSubject.create();
+            defaultStream = EventSubject.create();
+            
+            streamOfLetters = EventSubject.create();
+            
+            switchMapStream = streamOfLetters.switchMap(letter -> {
+                if ("A".equals(letter)) return streamA;
+                if ("B".equals(letter)) return streamB;
+                if ("C".equals(letter)) return streamC;
+                return defaultStream;
+            });
+        });
+    }
+
+    @Test
+    public void testSwitchMap() {
+        
+        assertFalse(streamA.hasObservers());
+        assertFalse(streamB.hasObservers());
+        assertFalse(streamC.hasObservers());
+        assertFalse(defaultStream.hasObservers());
+        
+        EventObserver<String> observer = Mockito.mock(EventObserver.class);
+        switchMapStream.observe(observer);
+        
+        assertFalse(streamA.hasObservers());
+        assertFalse(streamB.hasObservers());
+        assertFalse(streamC.hasObservers());
+        assertFalse(defaultStream.hasObservers());
+        
+        streamA.publish("Aevent");
+        streamB.publish("Bevent");
+        streamC.publish("Cevent");
+        defaultStream.publish("Defaultevent");
+        
+        Mockito.verify(observer, never()).onEvent(Mockito.any());
+        
+        streamOfLetters.publish("A");
+        
+        assertTrue(streamA.hasObservers());
+        assertFalse(streamB.hasObservers());
+        assertFalse(streamC.hasObservers());
+        assertFalse(defaultStream.hasObservers());
+        
+        streamA.publish("Aevent");
+        streamB.publish("Bevent");
+        streamC.publish("Cevent");
+        defaultStream.publish("Defaultevent");
+        
+        verify(observer).onEvent("Aevent");
+        Mockito.verifyNoMoreInteractions(observer);
+        
+        streamOfLetters.publish("B");
+        
+        assertFalse(streamA.hasObservers());
+        assertTrue(streamB.hasObservers());
+        assertFalse(streamC.hasObservers());
+        assertFalse(defaultStream.hasObservers());
+        
+        streamA.publish("Aevent");
+        streamB.publish("Bevent");
+        streamC.publish("Cevent");
+        defaultStream.publish("Defaultevent");
+        
+        verify(observer).onEvent("Bevent");
+        Mockito.verifyNoMoreInteractions(observer);
+        
+        streamOfLetters.publish("C");
+        
+        assertFalse(streamA.hasObservers());
+        assertFalse(streamB.hasObservers());
+        assertTrue(streamC.hasObservers());
+        assertFalse(defaultStream.hasObservers());
+        
+        streamA.publish("Aevent");
+        streamB.publish("Bevent");
+        streamC.publish("Cevent");
+        defaultStream.publish("Defaultevent");
+        
+        verify(observer).onEvent("Cevent");
+        Mockito.verifyNoMoreInteractions(observer);
+    }
+    
+    @Test
+    public void testDisposeUnsubscribesObserver() {
+        
+        Consumer<String> onEvent = Mockito.mock(Consumer.class);
+        Runnable onCompleted = Mockito.mock(Runnable.class);
+        
+        Subscription subscription = switchMapStream.observe(EventObserver.create(onEvent, onCompleted));
+        assertFalse(subscription.isDisposed());
+        
+        streamOfLetters.dispose();
+        verify(onCompleted).run();
+        assertTrue(subscription.isDisposed());
+        Mockito.verifyNoMoreInteractions(onEvent, onCompleted);
+    }
+    
+    @Test
+    public void testUnsubscribeRemovesObserver() throws Exception {
+        assertFalse(streamOfLetters.hasObservers());
+
+        EventObserver<String> observer = Mockito.mock(EventObserver.class);
+        Subscription subscription = switchMapStream.observe(observer);
+
+        assertFalse(streamA.hasObservers());
+
+        streamOfLetters.publish("A");
+
+        assertTrue(streamOfLetters.hasObservers());
+        assertTrue(streamA.hasObservers());
+
+        subscription.dispose();
+        assertFalse(streamOfLetters.hasObservers());
+        assertFalse(streamA.hasObservers());
+    }
+    
+    @Test
+    public void testSubscribeAfterDisposed() {
+        EventObserver<String> observer = Mockito.mock(EventObserver.class);
+        
+        streamOfLetters.dispose();
+        
+        Subscription subscription = switchMapStream.observe(observer);
+
+        verify(observer, Mockito.never()).onEvent(Mockito.anyString());
+        verify(observer).onCompleted();
+        Mockito.verifyNoMoreInteractions(observer);
+        
+        assertTrue(subscription.isDisposed());
+        assertFalse(streamOfLetters.hasObservers());
+    }
+    
+    @Test
+    public void testReentranceBlocked() {
+        EventObserver<String> observer = Mockito.mock(EventObserver.class);
+        
+        switchMapStream.observe(observer);
+        // this reentrant call should be blocked.
+        switchMapStream.onEvent(event -> streamA.publish("burritos"));
+        
+        streamOfLetters.publish("A");
+        streamA.publish("tacos");
+        
+        verify(observer).onEvent("tacos");
+        verify(observer, never()).onEvent("burritos");
+    }
+}

--- a/src/test/java/mb/rxui/event/publisher/TestFlattenPublisher.java
+++ b/src/test/java/mb/rxui/event/publisher/TestFlattenPublisher.java
@@ -28,11 +28,11 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.event.EventObserver;
 import mb.rxui.event.EventStream;
 import mb.rxui.event.EventSubject;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestFlattenPublisher {

--- a/src/test/java/mb/rxui/event/publisher/TestMergePublisher.java
+++ b/src/test/java/mb/rxui/event/publisher/TestMergePublisher.java
@@ -27,11 +27,11 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.event.EventObserver;
 import mb.rxui.event.EventStream;
 import mb.rxui.event.EventSubject;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestMergePublisher {

--- a/src/test/java/mb/rxui/property/TestCombineLatest.java
+++ b/src/test/java/mb/rxui/property/TestCombineLatest.java
@@ -23,8 +23,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestCombineLatest {

--- a/src/test/java/mb/rxui/property/TestProperty.java
+++ b/src/test/java/mb/rxui/property/TestProperty.java
@@ -31,9 +31,9 @@ import org.mockito.InOrder;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.event.EventSubject;
+import mb.rxui.subscription.Subscription;
 import rx.Observable;
 import rx.functions.Action0;
 import rx.functions.Action1;

--- a/src/test/java/mb/rxui/property/TestPropertyChangeEvents.java
+++ b/src/test/java/mb/rxui/property/TestPropertyChangeEvents.java
@@ -22,9 +22,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.event.EventSequenceGenerator;
+import mb.rxui.subscription.Subscription;
 import mb.rxui.event.EventObserver;
 
 @RunWith(SwingTestRunner.class)

--- a/src/test/java/mb/rxui/property/TestPropertyStream.java
+++ b/src/test/java/mb/rxui/property/TestPropertyStream.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.event.EventSequenceGenerator;
 import mb.rxui.event.EventStream;
+import mb.rxui.subscription.Subscription;
 import rx.functions.Action0;
 import rx.functions.Action1;
 

--- a/src/test/java/mb/rxui/property/javafx/TestJavaFxProperties.java
+++ b/src/test/java/mb/rxui/property/javafx/TestJavaFxProperties.java
@@ -29,11 +29,11 @@ import org.mockito.Mockito;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.concurrent.Task;
-import mb.rxui.Subscription;
 import mb.rxui.property.Property;
 import mb.rxui.property.PropertyStream;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.javafx.JavaFxProperties;
+import mb.rxui.subscription.Subscription;
 
 public class TestJavaFxProperties {
     

--- a/src/test/java/mb/rxui/property/opertator/TestFilterProperty.java
+++ b/src/test/java/mb/rxui/property/opertator/TestFilterProperty.java
@@ -20,11 +20,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.event.EventStream;
 import mb.rxui.event.EventObserver;
 import mb.rxui.property.Property;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestFilterProperty {

--- a/src/test/java/mb/rxui/property/opertator/TestOperatorFilterToOptional.java
+++ b/src/test/java/mb/rxui/property/opertator/TestOperatorFilterToOptional.java
@@ -25,11 +25,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.property.Property;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.PropertyStream;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestOperatorFilterToOptional {

--- a/src/test/java/mb/rxui/property/opertator/TestOperatorIs.java
+++ b/src/test/java/mb/rxui/property/opertator/TestOperatorIs.java
@@ -20,12 +20,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.property.Property;
 import mb.rxui.property.PropertyStream;
 import mb.rxui.property.PropertyObserver;
 import mb.rxui.property.operator.OperatorIs;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestOperatorIs {

--- a/src/test/java/mb/rxui/property/opertator/TestOperatorIsDirty.java
+++ b/src/test/java/mb/rxui/property/opertator/TestOperatorIsDirty.java
@@ -20,10 +20,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.property.Property;
 import mb.rxui.property.PropertyStream;
+import mb.rxui.subscription.Subscription;
 import mb.rxui.property.PropertyObserver;
 
 @RunWith(SwingTestRunner.class)

--- a/src/test/java/mb/rxui/property/opertator/TestOperatorMap.java
+++ b/src/test/java/mb/rxui/property/opertator/TestOperatorMap.java
@@ -23,10 +23,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.property.Property;
 import mb.rxui.property.PropertyStream;
+import mb.rxui.subscription.Subscription;
 import mb.rxui.property.PropertyObserver;
 
 @RunWith(SwingTestRunner.class)

--- a/src/test/java/mb/rxui/property/opertator/TestOperatorTake.java
+++ b/src/test/java/mb/rxui/property/opertator/TestOperatorTake.java
@@ -20,10 +20,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.property.Property;
 import mb.rxui.property.PropertyStream;
+import mb.rxui.subscription.Subscription;
 import mb.rxui.property.PropertyObserver;
 
 @RunWith(SwingTestRunner.class)

--- a/src/test/java/mb/rxui/property/opertator/TestPropertyConditionBuilder.java
+++ b/src/test/java/mb/rxui/property/opertator/TestPropertyConditionBuilder.java
@@ -21,9 +21,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
 import mb.rxui.SwingTestRunner;
 import mb.rxui.property.Property;
+import mb.rxui.subscription.Subscription;
 
 @RunWith(SwingTestRunner.class)
 public class TestPropertyConditionBuilder {

--- a/src/test/java/mb/rxui/subscription/TestCompositeSubscription.java
+++ b/src/test/java/mb/rxui/subscription/TestCompositeSubscription.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package mb.rxui.property;
+package mb.rxui.subscription;
 
 import static org.junit.Assert.*;
 
@@ -21,7 +21,8 @@ import org.junit.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
-import mb.rxui.Subscription;
+import mb.rxui.subscription.CompositeSubscription;
+import mb.rxui.subscription.Subscription;
 
 public class TestCompositeSubscription {
     

--- a/src/test/java/mb/rxui/subscription/TestRollingSubscription.java
+++ b/src/test/java/mb/rxui/subscription/TestRollingSubscription.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2015 Mike Baum
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package mb.rxui.subscription;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class TestRollingSubscription {
+
+    @Test
+    public void testUnsubscribesPrevious() {
+        RollingSubscription subscription = new RollingSubscription();
+        
+        Subscription sub1 = Mockito.mock(Subscription.class);
+        
+        subscription.set(sub1);
+        verifyNoMoreInteractions(sub1);
+        
+        Subscription sub2 = Mockito.mock(Subscription.class);
+        subscription.set(sub2);
+        Mockito.verify(sub1).dispose();
+        verifyNoMoreInteractions(sub2);
+    }
+    
+    @Test
+    public void testAddSubAfterDispose() {
+        RollingSubscription subscription = new RollingSubscription();
+        
+        subscription.dispose();
+        
+        Subscription sub1 = Mockito.mock(Subscription.class);
+        
+        subscription.set(sub1);
+        Mockito.verify(sub1).dispose();
+    }
+}


### PR DESCRIPTION
This partially fixes Issue #45. Still need to add a variant of this method that switches between Properties.

As part of this task, I fixed an issue with the LiftEventPublisher, where dispose notifications where not being communicated up the chain.
- Added Counter to be able to increment and decrement a count within a lambda.
- Added RollingSubscription which is a container for subscriptions that can only contain one at a time and disposes the existing when being updated.
- Moved all subscription classes into their own package.
